### PR TITLE
feat: 공지사항 전체 조회 createdAt, id desc & test 수정

### DIFF
--- a/src/main/java/kr/co/pinup/notices/Notice.java
+++ b/src/main/java/kr/co/pinup/notices/Notice.java
@@ -1,21 +1,17 @@
 package kr.co.pinup.notices;
 
 import jakarta.persistence.*;
-
 import kr.co.pinup.BaseEntity;
 import kr.co.pinup.members.Member;
 import kr.co.pinup.notices.model.dto.NoticeUpdateRequest;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import lombok.*;
 
 @Entity
 @Table(name = "notices")
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Notice extends BaseEntity {
 
     @Column(nullable = false, length = 100)
@@ -27,15 +23,6 @@ public class Notice extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
     private Member member;
-
-    @Builder
-    public Notice(String title, String content, Member member, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.title = title;
-        this.content = content;
-        this.member = member;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
 
     public void update(NoticeUpdateRequest update) {
         title = update.title();

--- a/src/main/java/kr/co/pinup/notices/repository/NoticeRepository.java
+++ b/src/main/java/kr/co/pinup/notices/repository/NoticeRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    List<Notice> findAllByOrderByCreatedAtDesc();
+    List<Notice> findAllByOrderByCreatedAtDescIdDesc();
 }

--- a/src/main/java/kr/co/pinup/notices/service/NoticeService.java
+++ b/src/main/java/kr/co/pinup/notices/service/NoticeService.java
@@ -27,7 +27,7 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
 
     public List<NoticeResponse> findAll() {
-        return noticeRepository.findAllByOrderByCreatedAtDesc()
+        return noticeRepository.findAllByOrderByCreatedAtDescIdDesc()
                 .stream()
                 .map(NoticeResponse::new)
                 .collect(Collectors.toList());

--- a/src/test/java/kr/co/pinup/notices/NoticeServiceTest.java
+++ b/src/test/java/kr/co/pinup/notices/NoticeServiceTest.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -103,11 +102,10 @@ class NoticeServiceTest {
         // given
         List<Notice> request = IntStream.range(1, 3)
                 .mapToObj(i -> Notice.builder()
-                        .title("공지사항 제목 " + i)
-                        .content("공지사항 내용 " + i)
-                        .member(member)
-                        .createdAt(LocalDateTime.now().plusNanos(i * 1000000000L))
-                        .build())
+                            .title("공지사항 제목 " + i)
+                            .content("공지사항 내용 " + i)
+                            .member(member)
+                            .build())
                 .toList();
         noticeRepository.saveAll(request);
 


### PR DESCRIPTION
## 공지사항

- 전체 조회 시 정렬 필드 수정
  - createdAt desc -> createdAt desc, id desc로 변경
- 테스트에서 회원에 대한 세션 삽입 추가