### PR TITLE
feat: FAQ 전체 조회 createdAt, id desc & test 수정

### DIFF
--- a/src/main/java/kr/co/pinup/faqs/Faq.java
+++ b/src/main/java/kr/co/pinup/faqs/Faq.java
@@ -7,12 +7,12 @@ import kr.co.pinup.faqs.model.enums.FaqCategory;
 import kr.co.pinup.members.Member;
 import lombok.*;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "faqs")
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Faq extends BaseEntity {
 
     @Column(nullable = false, length = 100)
@@ -28,17 +28,6 @@ public class Faq extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
-
-    @Builder
-    public Faq(String question, String answer, FaqCategory category,
-               Member member, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.question = question;
-        this.answer = answer;
-        this.category = category;
-        this.member = member;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
 
     public void update(FaqUpdateRequest faqUpdate) {
         question = faqUpdate.question();

--- a/src/main/java/kr/co/pinup/faqs/repository/FaqRepository.java
+++ b/src/main/java/kr/co/pinup/faqs/repository/FaqRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface FaqRepository extends JpaRepository<Faq, Long> {
 
-    List<Faq> findAllByOrderByCreatedAtDesc();
+    List<Faq> findAllByOrderByCreatedAtDescIdDesc();
 }

--- a/src/main/java/kr/co/pinup/faqs/service/FaqService.java
+++ b/src/main/java/kr/co/pinup/faqs/service/FaqService.java
@@ -44,7 +44,7 @@ public class FaqService {
     }
 
     public List<FaqResponse> findAll() {
-        return faqRepository.findAllByOrderByCreatedAtDesc()
+        return faqRepository.findAllByOrderByCreatedAtDescIdDesc()
                 .stream()
                 .map(FaqResponse::new)
                 .collect(Collectors.toList());

--- a/src/test/java/kr/co/pinup/faqs/FaqServiceTest.java
+++ b/src/test/java/kr/co/pinup/faqs/FaqServiceTest.java
@@ -112,7 +112,6 @@ class FaqServiceTest {
                         .question("이거 어떻게 해야 하나요 " + i + "?")
                         .answer("이렇게 하시면 됩니다. " + i)
                         .member(member)
-                        .createdAt(LocalDateTime.now().plusNanos(i * 1000000000L))
                         .build())
                 .toList();
         faqRepository.saveAll(request);

--- a/src/test/java/kr/co/pinup/faqs/controller/FaqApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/faqs/controller/FaqApiControllerTest.java
@@ -13,6 +13,7 @@ import kr.co.pinup.members.model.enums.MemberRole;
 import kr.co.pinup.oauth.OAuthProvider;
 import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.*;
@@ -57,15 +59,21 @@ class FaqApiControllerTest {
     @MockitoBean
     private FaqService faqService;
 
-    @Test
-    @DisplayName("FAQ 저장")
-    void save() throws Exception {
-        // given
-        MemberInfo mockMemberInfo = MemberInfo.builder()
+    MemberInfo mockMemberInfo;
+
+    @BeforeEach
+    void setUp() {
+        mockMemberInfo = MemberInfo.builder()
                 .nickname("두려운고양이")
                 .provider(OAuthProvider.NAVER)
                 .role(MemberRole.ROLE_ADMIN)
                 .build();
+    }
+
+    @Test
+    @DisplayName("FAQ 저장")
+    void save() throws Exception {
+        // given
         FaqCreateRequest request = FaqCreateRequest.builder()
                 .category("USE")
                 .question("이거 어떻게 해야 하나요?")
@@ -96,8 +104,9 @@ class FaqApiControllerTest {
 
         // expected
         mockMvc.perform(post("/api/faqs")
-                .contentType(APPLICATION_JSON)
-                .content(body))
+                        .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
+                        .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
                 .andExpect(jsonPath("$.message").value("잘못된 요청입니다."))
@@ -120,6 +129,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(post("/api/faqs")
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -144,6 +154,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(post("/api/faqs")
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -168,6 +179,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(post("/api/faqs")
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -192,6 +204,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(post("/api/faqs")
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -282,11 +295,6 @@ class FaqApiControllerTest {
     void update() throws Exception {
         // given
         long faqId = 1L;
-        MemberInfo mockMemberInfo = MemberInfo.builder()
-                .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
-                .role(MemberRole.ROLE_ADMIN)
-                .build();
         FaqUpdateRequest request = FaqUpdateRequest.builder()
                 .category("USE")
                 .question("질문")
@@ -309,7 +317,6 @@ class FaqApiControllerTest {
     void invalidQuestionToUpdate() throws Exception {
         // given
         long faqId = 1L;
-
         FaqUpdateRequest request = FaqUpdateRequest.builder()
                 .category("USE")
                 .answer("이렇게 저렇게 하시면 됩니다.")
@@ -320,6 +327,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(put("/api/faqs/{faqId}", faqId)
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -334,7 +342,6 @@ class FaqApiControllerTest {
     void invalidQuestionLengthToUpdate() throws Exception {
         // given
         long faqId = 1L;
-
         FaqUpdateRequest request = FaqUpdateRequest.builder()
                 .category("USE")
                 .question("A".repeat(101))
@@ -346,6 +353,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(put("/api/faqs/{faqId}", faqId)
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -361,7 +369,6 @@ class FaqApiControllerTest {
     void invalidAnswerToUpdate() throws Exception {
         // given
         long faqId = 1L;
-
         FaqUpdateRequest request = FaqUpdateRequest.builder()
                 .category("USE")
                 .question("이거 어떻게 해야 하나요?")
@@ -372,6 +379,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(put("/api/faqs/{faqId}", faqId)
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -386,7 +394,6 @@ class FaqApiControllerTest {
     void invalidAnswerLengthToUpdate() throws Exception {
         // given
         long faqId = 1L;
-
         FaqUpdateRequest request = FaqUpdateRequest.builder()
                 .category("USE")
                 .question("이거 어떻게 해야 하나요?")
@@ -398,6 +405,7 @@ class FaqApiControllerTest {
         // expected
         mockMvc.perform(put("/api/faqs/{faqId}", faqId)
                         .contentType(APPLICATION_JSON)
+                        .sessionAttr("memberInfo", mockMemberInfo)
                         .content(body))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(BAD_REQUEST.value()))
@@ -413,11 +421,6 @@ class FaqApiControllerTest {
     void updateWithNonExistId() throws Exception {
         // given
         long faqId = Long.MAX_VALUE;
-        MemberInfo mockMemberInfo = MemberInfo.builder()
-                .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
-                .role(MemberRole.ROLE_ADMIN)
-                .build();
         FaqUpdateRequest request = FaqUpdateRequest.builder()
                 .category("USE")
                 .question("질문")
@@ -440,7 +443,9 @@ class FaqApiControllerTest {
                 .andDo(print())
                 .andReturn();
 
-        ErrorResponse response = (ErrorResponse) result.getModelAndView().getModel().get("error");
+        ErrorResponse response = (ErrorResponse) Objects.requireNonNull(result.getModelAndView())
+                .getModel()
+                .get("error");
         assertThat(response.status()).isEqualTo(NOT_FOUND.value());
         assertThat(response.message()).isEqualTo("FAQ가 존재하지 않습니다.");
     }
@@ -450,11 +455,6 @@ class FaqApiControllerTest {
     void remove() throws Exception {
         // given
         long faqId = 1L;
-        MemberInfo mockMemberInfo = MemberInfo.builder()
-                .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
-                .role(MemberRole.ROLE_ADMIN)
-                .build();
 
         // when
         doNothing().when(faqService).remove(faqId);
@@ -471,11 +471,6 @@ class FaqApiControllerTest {
     void removeWithNonExistId() throws Exception {
         // given
         long faqId = Long.MAX_VALUE;
-        MemberInfo mockMemberInfo = MemberInfo.builder()
-                .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
-                .role(MemberRole.ROLE_ADMIN)
-                .build();
 
         // when
         doThrow(new FaqNotFound()).when(faqService).remove(faqId);
@@ -489,7 +484,9 @@ class FaqApiControllerTest {
                 .andDo(print())
                 .andReturn();
 
-        ErrorResponse response = (ErrorResponse) result.getModelAndView().getModel().get("error");
+        ErrorResponse response = (ErrorResponse) Objects.requireNonNull(result.getModelAndView())
+                .getModel()
+                .get("error");
         assertThat(response.status()).isEqualTo(NOT_FOUND.value());
         assertThat(response.message()).isEqualTo("FAQ가 존재하지 않습니다.");
     }

--- a/src/test/java/kr/co/pinup/faqs/controller/FaqControllerTest.java
+++ b/src/test/java/kr/co/pinup/faqs/controller/FaqControllerTest.java
@@ -7,6 +7,7 @@ import kr.co.pinup.members.model.dto.MemberInfo;
 import kr.co.pinup.members.model.enums.MemberRole;
 import kr.co.pinup.members.service.MemberService;
 import kr.co.pinup.oauth.OAuthProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,9 +45,19 @@ class FaqControllerTest {
     @MockitoBean
     MemberService memberService;
 
+    MemberInfo mockMemberInfo;
+
+    @BeforeEach
+    void setUp() {
+        mockMemberInfo = MemberInfo.builder()
+                .nickname("두려운고양이")
+                .provider(OAuthProvider.NAVER)
+                .role(MemberRole.ROLE_ADMIN)
+                .build();
+    }
+
     @Test
     @DisplayName("FAQ 리스트 페이지 이동")
-    @WithAnonymousUser
     void listPage() throws Exception {
         // given
         List<FaqResponse> mockFaqs = IntStream.range(0, 5)
@@ -61,7 +72,8 @@ class FaqControllerTest {
         when(faqService.findAll()).thenReturn(mockFaqs);
 
         // expected
-        mockMvc.perform(get("/faqs"))
+        mockMvc.perform(get("/faqs")
+                        .sessionAttr("memberInfo", mockMemberInfo))
                 .andExpect(status().isOk())
                 .andExpect(view().name(VIEW_PATH + "/list"))
                 .andExpect(model().attributeExists("faqs"))
@@ -73,11 +85,6 @@ class FaqControllerTest {
     @DisplayName("FAQ 생성 페이지 이동")
     void newPage() throws Exception {
         // given
-        MemberInfo mockMemberInfo = MemberInfo.builder()
-                .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
-                .role(MemberRole.ROLE_ADMIN)
-                .build();
 
         // expected
         mockMvc.perform(get("/faqs/new")
@@ -94,15 +101,9 @@ class FaqControllerTest {
 
     @Test
     @DisplayName("FAQ 수정 페이지 이동")
-    @WithMockUser(username = "testuser", roles = "ADMIN")
     void updatePage() throws Exception {
         // given
         long faqId = 1L;
-        MemberInfo mockMemberInfo = MemberInfo.builder()
-                .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
-                .role(MemberRole.ROLE_ADMIN)
-                .build();
         FaqResponse mockFaq = FaqResponse.builder()
                 .category("이용")
                 .question("질문")


### PR DESCRIPTION
## FAQ

- 전체 조회 시 정렬 필드 수정
  - createdAt desc -> createdAt desc, id desc로 변경
- 테스트에서 회원에 대한 세션 삽입 추가
