### PR TITLE
Feat comments

### DIFF
--- a/src/main/java/kr/co/pinup/comments/controller/CommentApiController.java
+++ b/src/main/java/kr/co/pinup/comments/controller/CommentApiController.java
@@ -11,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
 @RestController
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/kr/co/pinup/comments/model/dto/CommentResponse.java
+++ b/src/main/java/kr/co/pinup/comments/model/dto/CommentResponse.java
@@ -1,32 +1,17 @@
 package kr.co.pinup.comments.model.dto;
 
 import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
-@Getter
+
 @Builder
-public class CommentResponse {
-    private Long id;
-    private Long postId;
-    private Long userId;
-    private String content;
-    private LocalDateTime createdAt;
-
-    public static List<CommentResponse> fromList(List<CommentResponse> comments) {
-        return comments.stream()
-                .map(comment -> new CommentResponse(
-                        comment.getId(),
-                        comment.getPostId(),
-                        comment.getUserId(),
-                        comment.getContent(),
-                        comment.getCreatedAt()
-                ))
-                .collect(Collectors.toList());
-    }
+public record CommentResponse(
+        Long id,
+        Long postId,
+        Long userId,
+        String content,
+        LocalDateTime createdAt
+) {
 
 }
-

--- a/src/main/java/kr/co/pinup/comments/model/dto/CreateCommentRequest.java
+++ b/src/main/java/kr/co/pinup/comments/model/dto/CreateCommentRequest.java
@@ -2,15 +2,14 @@ package kr.co.pinup.comments.model.dto;
 
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@Builder(toBuilder = true)
-public class CreateCommentRequest {
-    private Long postId;
-    private Long userId;
+@Builder
+public record CreateCommentRequest(
+        Long postId,
+        Long userId,
 
-    @NotEmpty(message = "내용을 입력해주세요.")
-    private String content;
-
+        @NotEmpty(message = "내용을 입력해주세요.")
+        String content
+) {
 }
+

--- a/src/main/java/kr/co/pinup/comments/service/CommentService.java
+++ b/src/main/java/kr/co/pinup/comments/service/CommentService.java
@@ -45,7 +45,7 @@ public class CommentService  {
         Comment comment = Comment.builder()
                 .post(post)
                 .userId(1L)
-                .content(commentRequest.getContent())
+                .content(commentRequest.content())
                 .build();
 
         Comment savedComment = commentRepository.save(comment);

--- a/src/main/resources/static/js/comment.js
+++ b/src/main/resources/static/js/comment.js
@@ -1,10 +1,11 @@
 document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.delete-comment-btn').forEach(button => {
-        button.addEventListener('click', async (e) => {
-            e.preventDefault();
+    const commentList = document.getElementById('comment-list'); // 댓글 리스트
 
-            const commentId = button.getAttribute('data-comment-id');
-            const commentItem = button.closest('li');
+    commentList.addEventListener('click', async (e) => {
+
+        if (e.target && e.target.classList.contains('delete-comment-btn')) {
+            const commentId = e.target.getAttribute('data-comment-id');
+            const commentItem = e.target.closest('li');
 
             try {
                 const response = await fetch(`/api/comment/${commentId}`, {
@@ -12,7 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
 
                 if (response.ok) {
-                    commentItem.remove();
+                    commentItem.remove(); // 삭제된 댓글을 화면에서 제거
                 } else {
                     throw new Error('댓글 삭제 실패');
                 }
@@ -20,9 +21,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 console.error('댓글 삭제 실패:', error);
                 alert("댓글 삭제 실패: " + error.message);
             }
-        });
+        }
     });
 });
+
 
 document.addEventListener('DOMContentLoaded', () => {
     const commentForm = document.getElementById('comment-form');
@@ -50,8 +52,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
 
                 if (response.ok) {
-                    const newComment = await response.json(); // 서버 응답으로 받은 댓글 데이터
-                    console.log('서버 응답 데이터:', newComment);
+                    const newComment = await response.json();
 
                     const newCommentElement = document.createElement('li');
                     newCommentElement.setAttribute('data-id', newComment.id);

--- a/src/test/java/kr/co/pinup/comments/controller/CommentApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/comments/controller/CommentApiControllerTest.java
@@ -1,7 +1,6 @@
-package kr.co.pinup.posts.controller;
+package kr.co.pinup.comments.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kr.co.pinup.comments.controller.CommentApiController;
 import kr.co.pinup.comments.model.dto.CommentResponse;
 import kr.co.pinup.comments.model.dto.CreateCommentRequest;
 import kr.co.pinup.comments.service.CommentService;

--- a/src/test/java/kr/co/pinup/comments/service/CommentServiceTest.java
+++ b/src/test/java/kr/co/pinup/comments/service/CommentServiceTest.java
@@ -1,11 +1,10 @@
-package kr.co.pinup.posts.service;
+package kr.co.pinup.comments.service;
 
 import kr.co.pinup.comments.Comment;
 import kr.co.pinup.comments.exception.comment.CommentNotFoundException;
 import kr.co.pinup.comments.model.dto.CommentResponse;
 import kr.co.pinup.comments.model.dto.CreateCommentRequest;
 import kr.co.pinup.comments.repository.CommentRepository;
-import kr.co.pinup.comments.service.CommentService;
 import kr.co.pinup.posts.Post;
 import kr.co.pinup.posts.exception.post.PostNotFoundException;
 import kr.co.pinup.posts.repository.PostRepository;
@@ -123,11 +122,11 @@ public class CommentServiceTest {
         CommentResponse result = commentService.createComment(postId, createCommentRequest);
 
         assertNotNull(result);
-        assertEquals(1L, expectedResponse.getId());
-        assertEquals(expectedResponse.getPostId(), result.getPostId());
-        assertEquals(expectedResponse.getUserId(), result.getUserId());
-        assertEquals(expectedResponse.getContent(), result.getContent());
-        assertEquals(expectedResponse.getCreatedAt(), result.getCreatedAt());
+        assertEquals(1L, expectedResponse.id());
+        assertEquals(expectedResponse.postId(), result.postId());
+        assertEquals(expectedResponse.userId(), result.userId());
+        assertEquals(expectedResponse.content(), result.content());
+        assertEquals(expectedResponse.createdAt(), result.createdAt());
 
         verify(postRepository).findById(postId);
         verify(commentRepository).save(any(Comment.class));


### PR DESCRIPTION
### PR 제목:

Refactor: DTO를 Record로 변경 및 Comments 테스트 코드 분리

Fix: 댓글 삭제 버튼 이벤트 위임 적용

### PR 내용:

---

### 1. **DTO를 Record로 변경 및 리팩토링**

- `CommentResponse`와 `CreateCommentRequest`를 `record`로 변경하여 불변성과 간결성을 유지했습니다.
- `fromList` 메서드에서 불필요한 스트림 변환을 제거하여 성능을 개선했습니다.
- `@Builder`를 적용하여 코드의 가독성과 사용 편의성을 향상시켰습니다.

---

### 2. **댓글 삭제 버튼 이벤트 위임 적용**

- 기존에 동적으로 생성된 댓글에 대해 삭제 버튼 이벤트가 작동하지 않는 문제를 해결하기 위해 댓글 리스트에 이벤트 위임을 적용했습니다.
- 이 수정으로, 동적으로 생성된 댓글에 대해서도 삭제 버튼 클릭 시 정상적으로 삭제가 이루어지도록 했습니다.

---

### 3. **테스트 코드 분리**

- `Comments` 관련 테스트 코드를 별도로 분리하여 테스트 코드의 가독성과 유지보수성을 개선했습니다.