### PR TITLE
댓글 엔티티 리팩토링 및 관련 로직 수정

### DIFF
--- a/src/main/java/kr/co/pinup/comments/Comment.java
+++ b/src/main/java/kr/co/pinup/comments/Comment.java
@@ -3,6 +3,7 @@ package kr.co.pinup.comments;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import kr.co.pinup.BaseEntity;
+import kr.co.pinup.members.Member;
 import kr.co.pinup.posts.Post;
 import lombok.*;
 
@@ -19,8 +20,9 @@ public class Comment extends BaseEntity {
     @JsonBackReference
     private Post post;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
 
     @Column(name = "content", nullable = false)
     private String content;

--- a/src/main/java/kr/co/pinup/comments/controller/CommentApiController.java
+++ b/src/main/java/kr/co/pinup/comments/controller/CommentApiController.java
@@ -5,6 +5,8 @@ import jakarta.validation.Valid;
 import kr.co.pinup.comments.model.dto.CommentResponse;
 import kr.co.pinup.comments.model.dto.CreateCommentRequest;
 import kr.co.pinup.comments.service.CommentService;
+import kr.co.pinup.custom.loginMember.LoginMember;
+import kr.co.pinup.members.model.dto.MemberInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -26,8 +28,8 @@ public class CommentApiController {
     }
 
     @PostMapping("/{postId}")
-    public ResponseEntity<CommentResponse> createComment(@PathVariable Long postId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
-        return new ResponseEntity<>(commentService.createComment(postId, createCommentRequest), HttpStatus.CREATED);
+    public ResponseEntity<CommentResponse> createComment(@LoginMember MemberInfo memberInfo, @PathVariable Long postId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
+        return new ResponseEntity<>(commentService.createComment(memberInfo, postId, createCommentRequest), HttpStatus.CREATED);
     }
 
 }

--- a/src/main/java/kr/co/pinup/comments/model/dto/CommentResponse.java
+++ b/src/main/java/kr/co/pinup/comments/model/dto/CommentResponse.java
@@ -2,6 +2,7 @@ package kr.co.pinup.comments.model.dto;
 
 import kr.co.pinup.members.Member;
 import lombok.Builder;
+
 import java.time.LocalDateTime;
 
 @Builder

--- a/src/main/java/kr/co/pinup/comments/model/dto/CommentResponse.java
+++ b/src/main/java/kr/co/pinup/comments/model/dto/CommentResponse.java
@@ -1,15 +1,14 @@
 package kr.co.pinup.comments.model.dto;
 
+import kr.co.pinup.members.Member;
 import lombok.Builder;
 import java.time.LocalDateTime;
-import java.util.List;
-
 
 @Builder
 public record CommentResponse(
         Long id,
         Long postId,
-        Long userId,
+        Member member,
         String content,
         LocalDateTime createdAt
 ) {

--- a/src/main/java/kr/co/pinup/comments/model/dto/CreateCommentRequest.java
+++ b/src/main/java/kr/co/pinup/comments/model/dto/CreateCommentRequest.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 
 @Builder
 public record CreateCommentRequest(
-        Long postId,
-        Long userId,
 
         @NotEmpty(message = "내용을 입력해주세요.")
         String content

--- a/src/main/java/kr/co/pinup/comments/service/CommentService.java
+++ b/src/main/java/kr/co/pinup/comments/service/CommentService.java
@@ -6,6 +6,10 @@ import kr.co.pinup.comments.exception.comment.CommentNotFoundException;
 import kr.co.pinup.comments.model.dto.CommentResponse;
 import kr.co.pinup.comments.model.dto.CreateCommentRequest;
 import kr.co.pinup.comments.repository.CommentRepository;
+import kr.co.pinup.members.Member;
+import kr.co.pinup.members.exception.MemberNotFoundException;
+import kr.co.pinup.members.model.dto.MemberInfo;
+import kr.co.pinup.members.repository.MemberRepository;
 import kr.co.pinup.posts.Post;
 import kr.co.pinup.posts.exception.post.PostNotFoundException;
 import kr.co.pinup.posts.repository.PostRepository;
@@ -23,6 +27,7 @@ public class CommentService  {
 
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
 
 
     public List<CommentResponse> findByPostId(Long postId) {
@@ -38,13 +43,16 @@ public class CommentService  {
     }
 
 
-    public CommentResponse createComment(Long postId, CreateCommentRequest commentRequest) {
+    public CommentResponse createComment(MemberInfo memberInfo, Long postId, CreateCommentRequest commentRequest) {
+        Member member = memberRepository.findByNickname(memberInfo.nickname())
+                .orElseThrow(() -> new MemberNotFoundException(memberInfo.nickname() + "님을 찾을 수 없습니다."));
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostNotFoundException("게시글을 찾을 수 없습니다."));
 
         Comment comment = Comment.builder()
                 .post(post)
-                .userId(1L)
+                .member(member)
                 .content(commentRequest.content())
                 .build();
 
@@ -53,7 +61,7 @@ public class CommentService  {
         return CommentResponse.builder()
                 .id(savedComment.getId())
                 .postId(savedComment.getPost().getId())
-                .userId(savedComment.getUserId())
+                .member(savedComment.getMember())
                 .content(savedComment.getContent())
                 .createdAt(savedComment.getCreatedAt())
                 .build();

--- a/src/main/resources/static/css/post_modal.css
+++ b/src/main/resources/static/css/post_modal.css
@@ -111,12 +111,32 @@
     display: flex;
     gap: 10px;
     padding: 5px 0;
+    border-bottom: 1px solid #ddd; /* 각 댓글 구분선 */
 }
 
 .comment-username {
     font-weight: bold;
+    font-size: 14px;
+    color: #333; /* 닉네임 색상 */
+    margin-right: 10px;
 }
 
+.comment-content {
+    display: flex;
+    gap: 10px;
+    flex-grow: 1;
+}
+
+.comment-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: #888;
+}
+.comment-delete {
+    font-size: 12px;
+}
 .comment-input {
     display: flex;
     border-top: 1px solid #ddd;

--- a/src/main/resources/static/js/post.js
+++ b/src/main/resources/static/js/post.js
@@ -329,7 +329,7 @@ function initializeCommentHandlers() {
 
                     newCommentElement.innerHTML = `
                         <div>
-                            <span>사용자 이릅</span>
+                          <span class="comment-username">${newComment.member.nickname}</span>
                             <span>${newComment.content}</span>
                             <button type="button" class="transparent-button" data-comment-id="${newComment.id}">삭제</button>
                         </div>

--- a/src/main/resources/templates/views/posts/detail.html
+++ b/src/main/resources/templates/views/posts/detail.html
@@ -70,14 +70,17 @@
                         <ul>
                             <th:block th:each="comment : ${post.comments}">
                                 <li class="comment">
-                                    <div>
+                                    <div class="comment-content">
                                         <span class="comment-username" th:text="${comment.member.nickname}"></span>
                                         <span th:text="${comment.content}"></span>
-                                        <button type="button" class="transparent-button" th:data-comment-id="${comment.id}">삭제</button>
                                     </div>
-                                    <div class="card-time" th:text="*{#temporals.format(comment.createdAt, 'yyyy-MM-dd')}"></div>
+                                    <div class="comment-footer">
+                                        <div class="card-time" th:text="*{#temporals.format(comment.createdAt, 'yyyy-MM-dd')}"></div>
+                                        <button type="button" class="comment-delete transparent-button" th:data-comment-id="${comment.id}">삭제</button>
+                                    </div>
                                 </li>
                             </th:block>
+
                         </ul>
                     </div>
                 </div>

--- a/src/main/resources/templates/views/posts/detail.html
+++ b/src/main/resources/templates/views/posts/detail.html
@@ -70,9 +70,8 @@
                         <ul>
                             <th:block th:each="comment : ${post.comments}">
                                 <li class="comment">
-                                    <!-- <span class="comment-username" th:text="${comment.user.username}"></span>-->
                                     <div>
-                                        <span>사용자 이릅</span>
+                                        <span class="comment-username" th:text="${comment.member.nickname}"></span>
                                         <span th:text="${comment.content}"></span>
                                         <button type="button" class="transparent-button" th:data-comment-id="${comment.id}">삭제</button>
                                     </div>

--- a/src/test/java/kr/co/pinup/comments/controller/CommentApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/comments/controller/CommentApiControllerTest.java
@@ -4,6 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pinup.comments.model.dto.CommentResponse;
 import kr.co.pinup.comments.model.dto.CreateCommentRequest;
 import kr.co.pinup.comments.service.CommentService;
+import kr.co.pinup.members.Member;
+import kr.co.pinup.members.custom.WithMockMember;
+import kr.co.pinup.members.model.dto.MemberInfo;
+import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.oauth.OAuthProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +19,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,23 +47,25 @@ class CommentApiControllerTest {
         objectMapper = new ObjectMapper();
         mockMvc = MockMvcBuilders.standaloneSetup(commentApiController).build();
     }
+
     @DisplayName("댓글 생성")
     @Test
+    @WithMockMember(nickname = "행복한 돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
     public void testCreateComment() throws Exception {
         Long postId = 1L;
+        Member mockMember = new Member( "행복한 돼지", "test@example.com", "happyPig", OAuthProvider.NAVER, "provider-id-123", MemberRole.ROLE_USER);
 
         CreateCommentRequest createCommentRequest = CreateCommentRequest.builder()
                 .content("This is a test comment")
-                .userId(1L)
                 .build();
 
         CommentResponse commentResponse = CommentResponse.builder()
                 .postId(postId)
-                .userId(1L)
+                .member(mockMember)
                 .content("This is a test comment")
                 .build();
 
-        when(commentService.createComment(eq(postId), any(CreateCommentRequest.class)))
+        when(commentService.createComment(any(MemberInfo.class), eq(postId), any(CreateCommentRequest.class)))
                 .thenReturn(commentResponse);
 
         mockMvc.perform(post("/api/comment/{postId}", postId)
@@ -64,11 +73,13 @@ class CommentApiControllerTest {
                         .content(objectMapper.writeValueAsString(createCommentRequest)))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.content").value("This is a test comment"))
-                .andExpect(jsonPath("$.userId").value(1L))
+                .andExpect(jsonPath("$.member.nickname").value(mockMember.getNickname())) // Member 객체 확인
                 .andExpect(jsonPath("$.postId").value(postId));
 
-        verify(commentService).createComment(eq(postId), any(CreateCommentRequest.class));
+        verify(commentService).createComment(any(MemberInfo.class), eq(postId), any(CreateCommentRequest.class));
     }
+
+
 
     @DisplayName("댓글 삭제")
     @Test


### PR DESCRIPTION
### PR 제목: **댓글 엔티티 리팩토링 및 관련 로직 수정**

### 변경 사항:

- **Comment 엔티티 리팩토링**: `userId`를 `Member` 엔티티로 변경하고, JPA 연관 관계를 설정했습니다.
- **Comment 생성 로직 수정**: `CommentService`와 `CommentApiController`에서 `Member` 객체를 직접 처리하도록 수정했습니다.
- **관련 DTO 수정**: `CreateCommentRequest`, `CommentResponse` DTO에서 `userId`를 `Member` 객체로 변경했습니다.
- **뷰 수정**: `detail.html`에서 댓글 출력 방식 수정 및 댓글 레이아웃 리팩토링, CSS 수정하여 더 나은 사용자 경험을 제공하도록 변경했습니다.
- **단위 테스트 수정**: `CommentControllerTest`, `CommentApiControllerTest`, `CommentServiceTest` 등 관련 테스트에서 기존의 `userId`를 `Member` 객체를 사용하도록 수정했습니다.

### 변경 이유:

- **엔티티 관계 개선**: `userId`를 `Member` 엔티티로 변경하여, JPA 연관 관계를 적절하게 설정하고, 객체 지향적으로 데이터를 처리할 수 있도록 개선했습니다.
- **비즈니스 로직 개선**: `CommentService`, `CommentApiController`에서 `Member` 객체를 직접 사용하여, 코드의 명확성 및 유지보수성을 높였습니다.
- **DTO와 뷰 변경**: `userId`를 `Member` 객체로 변경하여, 직관적이고 일관성 있는 데이터 처리 및 전달 방식을 개선했습니다.
- **테스트 코드 보강**: 엔티티 변경 사항에 맞춰 테스트 코드도 수정하여, 변경된 로직이 정상적으로 동작하는지 확인했습니다.

### 영향 범위:

- **Comment 생성 API**: `userId`를 `Member` 엔티티로 대체함에 따라, 해당 API의 파라미터 처리 및 데이터 저장 방식이 변경됨.
- **뷰 템플릿 (`detail.html`)**: 댓글 출력 방식 수정 및 댓글 레이아웃이 변경되어, 더 나은 사용자 경험을 제공하도록 수정됨.
- **단위 테스트**: 엔티티 관계 변경에 따른 테스트 코드 수정이 필요하며, 기존의 `userId`를 `Member` 객체로 처리하는 방식으로 업데이트됨.

### 추가 사항:

- **테스트 코드 업데이트**: `CommentControllerTest`, `CommentApiControllerTest`, `CommentServiceTest` 등의 테스트가 엔티티 관계 변경에 맞춰 정상적으로 동작하도록 수정됨.