### PR TITLE
feat: 인증이 필요하지 않는 메소드 ArgumentHandler 수행하지 않도록 변경

### DIFF
--- a/src/main/java/kr/co/pinup/notices/controller/NoticeController.java
+++ b/src/main/java/kr/co/pinup/notices/controller/NoticeController.java
@@ -2,7 +2,6 @@ package kr.co.pinup.notices.controller;
 
 import kr.co.pinup.custom.loginMember.LoginMember;
 import kr.co.pinup.members.model.dto.MemberInfo;
-import kr.co.pinup.members.model.dto.MemberResponse;
 import kr.co.pinup.members.service.MemberService;
 import kr.co.pinup.notices.service.NoticeService;
 import lombok.RequiredArgsConstructor;
@@ -26,10 +25,9 @@ public class NoticeController {
     private final MemberService memberService;
 
     @GetMapping
-    public String list(@LoginMember MemberInfo memberInfo, Model model) {
-        model.addAttribute("profile", getMember(memberInfo));
+    public String list(Model model) {
         model.addAttribute("notices", noticeService.findAll());
-
+        
         return VIEW_PATH + "/list";
     }
 
@@ -40,8 +38,7 @@ public class NoticeController {
     }
 
     @GetMapping("/{noticeId}")
-    public String detail(@LoginMember MemberInfo memberInfo, @PathVariable Long noticeId, Model model) {
-        model.addAttribute("profile", getMember(memberInfo));
+    public String detail(@PathVariable Long noticeId, Model model) {
         model.addAttribute("notice", noticeService.find(noticeId));
 
         return VIEW_PATH + "/detail";
@@ -50,18 +47,10 @@ public class NoticeController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @GetMapping("/{noticeId}/update")
     public String update(@LoginMember MemberInfo memberInfo, @PathVariable Long noticeId, Model model) {
-        model.addAttribute("profile", getMember(memberInfo));
+        model.addAttribute("profile", memberService.findMember(memberInfo));
         model.addAttribute("notice", noticeService.find(noticeId));
 
         return VIEW_PATH + "/update";
-    }
-
-    private MemberResponse getMember(MemberInfo memberInfo) {
-        if (memberInfo == null) {
-            return null;
-        }
-
-        return memberService.findMember(memberInfo);
     }
 
 }

--- a/src/test/java/kr/co/pinup/notices/NoticeServiceTest.java
+++ b/src/test/java/kr/co/pinup/notices/NoticeServiceTest.java
@@ -60,12 +60,11 @@ class NoticeServiceTest {
                 .role(MemberRole.ROLE_ADMIN)
                 .build();
         memberRepository.save(member);
-
-        noticeRepository.deleteAll();
     }
 
     @AfterEach
     void tearDown() {
+        noticeRepository.deleteAll();
         memberRepository.deleteAll();
     }
 
@@ -81,7 +80,6 @@ class NoticeServiceTest {
         // given
         MemberInfo memberInfo = MemberInfo.builder()
                 .nickname("두려운고양이")
-                .provider(OAuthProvider.NAVER)
                 .role(MemberRole.ROLE_ADMIN)
                 .build();
 
@@ -98,7 +96,7 @@ class NoticeServiceTest {
     }
 
     @Test
-    @Transactional
+    @Transactional(readOnly = true)
     @DisplayName("공지사항 전체 조회")
     void findAll() {
         // given
@@ -120,7 +118,7 @@ class NoticeServiceTest {
         assertThat(notices.get(0).content()).isEqualTo("공지사항 내용 2");
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     @ParameterizedTest
     @MethodSource("noticeProvider")
     @DisplayName("공지사항 단일 조회")

--- a/src/test/java/kr/co/pinup/notices/controller/NoticeApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/notices/controller/NoticeApiControllerTest.java
@@ -10,7 +10,6 @@ import kr.co.pinup.notices.model.dto.NoticeCreateRequest;
 import kr.co.pinup.notices.model.dto.NoticeResponse;
 import kr.co.pinup.notices.model.dto.NoticeUpdateRequest;
 import kr.co.pinup.notices.service.NoticeService;
-import kr.co.pinup.oauth.OAuthProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -63,7 +62,7 @@ class NoticeApiControllerTest {
     }
 
     @ParameterizedTest
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @MethodSource("noticeProvider")
     @DisplayName("공지사항 저장")
     void save(String title, String content) throws Exception {
@@ -84,7 +83,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 저장 시 title 값은 필수이다")
     void invalidTitleToSave() throws Exception {
         // given
@@ -107,7 +106,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 저장 시 title 길이는 1~100까지 이다")
     void invalidTitleLengthToSave() throws Exception {
         // given
@@ -131,7 +130,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 저장 시 content 값은 필수이다")
     void invalidContentToSave() throws Exception {
         // given
@@ -224,7 +223,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 수정")
     void update() throws Exception {
         // given
@@ -244,7 +243,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 수정은 title 값이 필수다")
     void invalidTitleToUpdate() throws Exception {
         // given
@@ -269,7 +268,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 수정은 content 값이 필수다")
     void invalidContentToUpdate() throws Exception {
         // given
@@ -294,7 +293,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("존재하지 않는 공지사항 수정")
     void updateError() throws Exception {
         // given
@@ -324,7 +323,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 삭제")
     void deleteTest() throws Exception {
         // given
@@ -340,7 +339,7 @@ class NoticeApiControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("존재하지 않는 공지사항 삭제")
     void deleteError() throws Exception {
         // given

--- a/src/test/java/kr/co/pinup/notices/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/pinup/notices/controller/NoticeControllerTest.java
@@ -6,14 +6,12 @@ import kr.co.pinup.members.model.enums.MemberRole;
 import kr.co.pinup.members.service.MemberService;
 import kr.co.pinup.notices.model.dto.NoticeResponse;
 import kr.co.pinup.notices.service.NoticeService;
-import kr.co.pinup.oauth.OAuthProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.test.context.support.WithAnonymousUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -44,7 +42,6 @@ class NoticeControllerTest {
     NoticeService noticeService;
 
     @Test
-    @WithAnonymousUser
     @DisplayName("공지사항 리스트 페이지 이동")
     void listPage() throws Exception {
         // given
@@ -68,7 +65,7 @@ class NoticeControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 생성 페이지 이동")
     void newPage() throws Exception {
         // given
@@ -81,7 +78,6 @@ class NoticeControllerTest {
     }
 
     @Test
-    @WithAnonymousUser
     @DisplayName("공지사항 상세 페이지 이동")
     void detailPage() throws Exception {
         // given
@@ -104,7 +100,7 @@ class NoticeControllerTest {
     }
 
     @Test
-    @WithMockMember(nickname = "두려운 고양이", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
+    @WithMockMember(role = MemberRole.ROLE_ADMIN)
     @DisplayName("공지사항 수정 페이지 이동")
     void updatePage() throws Exception {
         // given


### PR DESCRIPTION
### 변경 사항
## NoticeController
- **비인증 메소드**에서 `@LoginMember` 제거 : 전체, 단일 조회는 로그인하지 않아도 조회가 가능해야 한다. 그러므로 `@LoginMember`로 argumenthandler가 수행이 안되도록 제거.

## Test
- argumenthandler 수행이 안되니 `@WithAnonymouseUser`가 필요하지 않아 제거
- 조회에 대한 `@Transcational`은 read만 가능하도록 변경