### PR TITLE
feat: 테스트 MemberService Mock 의존 추가 & public, excluse url에 /api/faqs 등 추가

### DIFF
--- a/src/main/java/kr/co/pinup/security/SecurityConstants.java
+++ b/src/main/java/kr/co/pinup/security/SecurityConstants.java
@@ -8,7 +8,7 @@ public class SecurityConstants {
             "/stores", "/api/stores", "/api/stores/summary",
             "/post",
             "/notices", "/notices/{noticeId}", "/api/notices", "/api/notices/{noticeId}",
-            "/faqs", "/api/faqs"
+            "/faqs", "/api/faqs", "/api/faqs/{faqsId}"
     };
 
     // 필터 적용 제외할 URL 목록
@@ -18,6 +18,6 @@ public class SecurityConstants {
             "/stores", "/api/stores", "/api/stores/summary",
             "/post",
             "/notices", "/notices/{noticeId}", "/api/notices", "/api/notices/{noticeId}",
-            "/faqs", "/api/faqs"
+            "/faqs", "/api/faqs", "/api/faqs/{faqsId}"
     );
 }

--- a/src/main/java/kr/co/pinup/security/SecurityConstants.java
+++ b/src/main/java/kr/co/pinup/security/SecurityConstants.java
@@ -5,17 +5,19 @@ import java.util.List;
 public class SecurityConstants {
     public static final String[] PUBLIC_URLS = {
             "/", "/images/**", "/members/login", "/api/members/oauth/**",
-            "/notices", "/notices/{noticeId}", "/api/notices", "/api/notices/{noticeId}",
             "/stores", "/api/stores", "/api/stores/summary",
-            "/post", "/faqs"
+            "/post",
+            "/notices", "/notices/{noticeId}", "/api/notices", "/api/notices/{noticeId}",
+            "/faqs", "/api/faqs"
     };
 
     // 필터 적용 제외할 URL 목록
     public static final List<String> EXCLUDED_URLS = List.of(
             "/static/", "/templates/", "/css/", "/js/", "/images/", "/fonts/", "/error", "/favicon.ico",
             "/members/login", "/api/members/oauth/",
-            "/notices", "/notices/{noticeId}", "/api/notices", "/api/notices/{noticeId}",
             "/stores", "/api/stores", "/api/stores/summary",
-            "/post", "/faqs"
+            "/post",
+            "/notices", "/notices/{noticeId}", "/api/notices", "/api/notices/{noticeId}",
+            "/faqs", "/api/faqs"
     );
 }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -7,8 +7,7 @@
         <ul>
             <li><a th:href="@{/}">Home</a></li>
             <li><a th:href="@{/stores}">Store</a></li>
-            <li><a th:href="@{/notices}">Notices</a></li>
-            <li><a th:href="@{/faqs}">FaQ</a></li>
+            <li><a th:href="@{/notices}">Support</a></li>
         </ul>
     </nav>
     <div class="user-actions">

--- a/src/main/resources/templates/layouts/main.html
+++ b/src/main/resources/templates/layouts/main.html
@@ -25,8 +25,6 @@
 <script th:src="@{/js/member.js}"></script>
 <script th:src="@{/js/post.js}"></script>
 <script th:src="@{/js/store.js}"></script>
-<script th:src="@{/js/faq.js}"></script>
-<script th:src="@{/js/support.js}"></script>
 
 <script>
     async function fetchStoreSummaries() {

--- a/src/test/java/kr/co/pinup/faqs/controller/FaqApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/faqs/controller/FaqApiControllerTest.java
@@ -11,15 +11,12 @@ import kr.co.pinup.faqs.service.FaqService;
 import kr.co.pinup.members.custom.WithMockMember;
 import kr.co.pinup.members.model.enums.MemberRole;
 import kr.co.pinup.members.service.MemberService;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -39,7 +36,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import(SecurityConfigTest.class)
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(FaqApiController.class)
 class FaqApiControllerTest {
 

--- a/src/test/java/kr/co/pinup/faqs/controller/FaqApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/faqs/controller/FaqApiControllerTest.java
@@ -10,6 +10,8 @@ import kr.co.pinup.faqs.model.dto.FaqUpdateRequest;
 import kr.co.pinup.faqs.service.FaqService;
 import kr.co.pinup.members.custom.WithMockMember;
 import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.members.service.MemberService;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,13 +46,16 @@ class FaqApiControllerTest {
     static final String VIEWS_ERROR = "error";
 
     @Autowired
-    private MockMvc mockMvc;
+    MockMvc mockMvc;
 
     @Autowired
-    private ObjectMapper objectMapper;
+    ObjectMapper objectMapper;
 
     @MockitoBean
-    private FaqService faqService;
+    FaqService faqService;
+
+    @MockitoBean
+    MemberService memberService;
 
     @Test
     @WithMockMember(role = MemberRole.ROLE_ADMIN)

--- a/src/test/java/kr/co/pinup/faqs/controller/FaqControllerTest.java
+++ b/src/test/java/kr/co/pinup/faqs/controller/FaqControllerTest.java
@@ -5,6 +5,7 @@ import kr.co.pinup.faqs.model.dto.FaqResponse;
 import kr.co.pinup.faqs.service.FaqService;
 import kr.co.pinup.members.custom.WithMockMember;
 import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.members.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,9 @@ class FaqControllerTest {
 
     @MockitoBean
     FaqService faqService;
+
+    @MockitoBean
+    MemberService memberService;
 
     @Test
     @DisplayName("FAQ 리스트 페이지 이동")

--- a/src/test/java/kr/co/pinup/faqs/controller/FaqControllerTest.java
+++ b/src/test/java/kr/co/pinup/faqs/controller/FaqControllerTest.java
@@ -8,12 +8,10 @@ import kr.co.pinup.members.model.enums.MemberRole;
 import kr.co.pinup.members.service.MemberService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -27,7 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import(SecurityConfigTest.class)
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(FaqController.class)
 class FaqControllerTest {
 

--- a/src/test/java/kr/co/pinup/notices/controller/NoticeApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/notices/controller/NoticeApiControllerTest.java
@@ -13,7 +13,6 @@ import kr.co.pinup.notices.model.dto.NoticeUpdateRequest;
 import kr.co.pinup.notices.service.NoticeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,7 +21,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -43,7 +41,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import(SecurityConfigTest.class)
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(NoticeApiController.class)
 class NoticeApiControllerTest {
 

--- a/src/test/java/kr/co/pinup/notices/controller/NoticeApiControllerTest.java
+++ b/src/test/java/kr/co/pinup/notices/controller/NoticeApiControllerTest.java
@@ -5,6 +5,7 @@ import kr.co.pinup.config.SecurityConfigTest;
 import kr.co.pinup.exception.ErrorResponse;
 import kr.co.pinup.members.custom.WithMockMember;
 import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.members.service.MemberService;
 import kr.co.pinup.notices.exception.NoticeNotFound;
 import kr.co.pinup.notices.model.dto.NoticeCreateRequest;
 import kr.co.pinup.notices.model.dto.NoticeResponse;
@@ -56,6 +57,9 @@ class NoticeApiControllerTest {
 
     @MockitoBean
     NoticeService noticeService;
+
+    @MockitoBean
+    MemberService memberService;
 
     static Stream<Arguments> noticeProvider() {
         return Stream.of(arguments("공지사항 제목", "공지사항 내용"));

--- a/src/test/java/kr/co/pinup/notices/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/pinup/notices/controller/NoticeControllerTest.java
@@ -26,7 +26,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @Import(SecurityConfigTest.class)
-@ExtendWith(SpringExtension.class)
 @WebMvcTest(NoticeController.class)
 class NoticeControllerTest {
 

--- a/src/test/java/kr/co/pinup/notices/controller/NoticeControllerTest.java
+++ b/src/test/java/kr/co/pinup/notices/controller/NoticeControllerTest.java
@@ -3,6 +3,7 @@ package kr.co.pinup.notices.controller;
 import kr.co.pinup.config.SecurityConfigTest;
 import kr.co.pinup.members.custom.WithMockMember;
 import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.members.service.MemberService;
 import kr.co.pinup.notices.model.dto.NoticeResponse;
 import kr.co.pinup.notices.service.NoticeService;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +37,9 @@ class NoticeControllerTest {
 
     @MockitoBean
     NoticeService noticeService;
+
+    @MockitoBean
+    MemberService memberService;
 
     @Test
     @DisplayName("공지사항 리스트 페이지 이동")


### PR DESCRIPTION
# SecurityConstants

- Public, Excluded urls에 빠진 항목 추가
  - "/api/faqs", "/api/faqs/{faqId}"

# Tests

- SecurityConfigTest의 accessTokenValidationFilter(MemberService memberService, SecurityUtil securityUtil) 의존성
  - MemberService를 사용하지 않는데 SecurityConfigTest import로 인해 의존성으로 Mock MemberService가 필요해짐
  - 나중에 해결할 필요가 있어 보임

