### PR TITLE
refactor: .carousel-item → .post-carousel-item 클래스명 변경 및 스타일 수정

### DIFF
--- a/src/main/resources/static/css/post_list.css
+++ b/src/main/resources/static/css/post_list.css
@@ -176,7 +176,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between; /* 버튼과 닉네임 사이 간격 유지 */
-    padding: 10px 15px;
+    padding: 0px 15px;
     border-top: 1px solid #eee;
     border-radius: 0 0 10px 10px; /* 카드 모양과 어울리게 */
     position: absolute;

--- a/src/main/resources/static/css/post_modal.css
+++ b/src/main/resources/static/css/post_modal.css
@@ -420,7 +420,7 @@ article.card header > div {
 }
 
 /* 🔥 개별 이미지 항목 */
-.carousel-item {
+.post-carousel-item {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -449,23 +449,21 @@ article.card header > div {
 .slide-left {
     width: 48px;
     height: 48px;
-    background-image: url(https://mkt-cdn.pstatic.net/mkt/2024/09/diggingarchive/assets/img/sp-pc-v4.png#icon_slide_arrow);
-    background-repeat: no-repeat;
-    background-position: 0px -69px;
-    background-size: 281px auto;
-    -webkit-transform: rotate(180deg);
-    -ms-transform: rotate(180deg);
-    transform: rotate(180deg);
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
 }
 
 .slide-right {
-    right: 0;
     width: 48px;
     height: 48px;
-    background-image: url(https://mkt-cdn.pstatic.net/mkt/2024/09/diggingarchive/assets/img/sp-pc-v4.png#icon_slide_arrow);
-    background-repeat: no-repeat;
-    background-position: 0px -69px;
-    background-size: 281px auto;
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
 }
 
 /* 🔥 캐러셀 인디케이터 컨테이너 */

--- a/src/main/resources/templates/views/posts/detail.html
+++ b/src/main/resources/templates/views/posts/detail.html
@@ -4,6 +4,7 @@
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layouts/layout}">
 
+
 <div layout:fragment="content">
     <div class="instagram-post-popup" id="post-popup">
         <div class="post-content">
@@ -15,15 +16,11 @@
                         <div class="carousel-inner">
                             <ul class="carousel-list">
                                 <th:block th:each="image : ${images}">
-                                    <li class="carousel-item"><img th:src="${image.s3Url}" alt="Post Image"/></li>
+                                    <li class="post-carousel-item"><img th:src="${image.s3Url}" alt="Post Image"/></li>
                                 </th:block>
                             </ul>
-                            <div class="slide slide-left" style="display: none;">
-                                <button class="transparent-button"></button>
-                            </div>
-                            <div class="slide slide-right">
-                                <button class="transparent-button"></button>
-                            </div>
+                            <button class="slide slide-left" style="display: none;"><</button>
+                            <button class="slide slide-right">></button>
                         </div>
                         <footer class="pinup-carousel-indicators">
                             <th:block th:each="image, iterStat : ${images}">

--- a/src/main/resources/templates/views/posts/list.html
+++ b/src/main/resources/templates/views/posts/list.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" th:href="@{/css/post_modal.css}">
 </head>
 <body>
-<div class="wrap type_home">
+<div class="wrap type_home" style="width: 95%;">
     <div class="content">
         <div class="home_content_wrap">
             <div class="content_list">


### PR DESCRIPTION
### PR 제목:

**refactor: `.carousel-item` → `.post-carousel-item` 클래스명 변경 및 스타일 수정**

### PR 내용:

이번 PR에서는 `.carousel-item`을 `.post-carousel-item`으로 변경하여 클래스명을 더 명확하게 정리하고, 레이아웃 및 스타일을 개선하였습니다.

### 주요 변경 사항:

- 기존 `.carousel-item`을 `.post-carousel-item`으로 변경하여 가독성 및 명확성 향상
- `.slide-left`, `.slide-right` 버튼 스타일 조정 (배경 색상 및 크기 조정)
- `wrap type_home`의 `width`를 95%로 조정하여 레이아웃 최적화

### 테스트 내용:

- 슬라이드 버튼이 정상적으로 표시되는지 확인
- 이미지가 중앙 정렬되는지 확인
- 레이아웃이 변경된 부분에서 문제없는지 점검