### PR TITLE
feat: 게시물 이미지 수정 시 최소 2장 유효성 검사 로직 개선

### DIFF
--- a/src/main/java/kr/co/pinup/posts/controller/PostApiController.java
+++ b/src/main/java/kr/co/pinup/posts/controller/PostApiController.java
@@ -69,7 +69,7 @@ public class PostApiController {
     @PutMapping("/{postId}")
     public ResponseEntity<PostResponse> updatePost(@PathVariable Long postId,
                                                    @ModelAttribute @Valid UpdatePostRequest updatePostRequest,
-                                                   @RequestParam("imagesToDelete") List<String> imagesToDelete,
+                                                   @RequestParam(required = false) List<String> imagesToDelete,
                                                    @RequestParam("images") MultipartFile[] images) {
         Post post = postService.updatePost(postId, updatePostRequest, images, imagesToDelete);
         return ResponseEntity.ok(PostResponse.from(post));

--- a/src/main/resources/templates/views/posts/create.html
+++ b/src/main/resources/templates/views/posts/create.html
@@ -17,9 +17,9 @@
                     <div class="col-10 d-flex align-items-center">
                         <input type="file" id="images" name="images" multiple accept="image/*" style="display: none;"
                                onchange="fileCheck(event)">
-                        <label class="btn-upload col-6" onclick="fileUpload()">파일 첨부</label>
+                        <label class="btn-upload col-6" onclick="fileUpload(false)">파일 첨부</label>
                         <span id="fileName" th:text="${fileName != null ? fileName : '선택된 파일 없음'}">선택된 파일 없음</span>
-                        <span id="fileCountMessage" class="images-file-warning" style="display: none;">최소 2장의 사진을 업로드해야 합니다.</span>
+                        <span id="fileCountMessage" class="images-file-warning" style="display: none;"></span>
                     </div>
                 </div>
 

--- a/src/main/resources/templates/views/posts/update.html
+++ b/src/main/resources/templates/views/posts/update.html
@@ -11,8 +11,7 @@
 
                 <div class="row">
                     <h3>현재 사진</h3>
-                    <input type="hidden" id="imagesToDelete" name="imagesToDelete"
-                           th:value="${imagesToDelete != null ? imagesToDelete : ''}"/>
+                    <input type="hidden" id="imagesToDelete" th:value="${imagesToDelete != null ? imagesToDelete : ''}"/>
 
                     <div class="preview-box">
                         <th:block th:each="image : ${images}">
@@ -37,8 +36,9 @@
                     <div class="col-10 d-flex align-items-center">
                         <input type="file" id="images" name="images" multiple accept="image/*" style="display: none;"
                                onchange="fileCheck(event)">
-                        <label class="btn-upload col-6" onclick="fileUpload()">파일 첨부</label>
+                        <label class="btn-upload col-6" onclick="fileUpload(true)">파일 첨부</label>
                         <span id="fileName" th:text="${fileName != null ? fileName : '선택된 파일 없음'}">선택된 파일 없음</span>
+                        <span id="fileCountMessage" class="images-file-warning" style="display: none;"></span>
                     </div>
                 </div>
 


### PR DESCRIPTION
## 변경 사항

1. **게시물 이미지 최소 개수 검증 개선**
    - 게시글 생성 시 업로드 이미지가 2장 이상이어야 등록 가능하도록 검증 (`submitPost`)
    - 게시글 수정 시 `기존 이미지 + 첨부 이미지 ≥ 2장`인지 검증
    - 이미지 전체 삭제 후 아무 첨부도 없을 경우 요청 차단 및 경고 알림
2. **생성/수정 모드 구분 처리 (`isUpdateMode`)**
    - `fileUpload(true/false)` 호출 시 수정/생성 모드 설정
    - `DOMContentLoaded` 시 `updatePostForm` 존재 여부로 자동 수정 모드 진입 처리
    - 생성/수정 조건에 따라 문구 및 로직 동작 분기
3. **실시간 이미지 유효성 검사 및 경고 문구 표시**
    - 이미지 첨부 또는 삭제 체크 시 실시간으로 총 이미지 수 계산
    - 총 이미지가 2장 미만인 경우 경고 문구(`fileCountMessage`) 노출
    - 실시간 콘솔 로그로 디버깅 가능 (`[이미지 검사] 모드:` 로그 출력)
4. **JS 코드 리팩토링**
    - 이미지 수 계산 로직을 `checkImageCount()`로 공통 처리
    - `validateForm()`으로 submit 시 유효성 최종 체크
    - `fileCheck`, `toggleImageToDelete` 등 중복 로직 개선 및 조건 분기 처리
5. **Spring 컨트롤러 예외 대응**
    - `@RequestParam List<String> imagesToDelete` → `required = false`로 변경
    - 이미지 삭제 요청 없이 수정할 때 400 에러 발생하지 않도록 대응

---

## 변경 이유

- **발단**: 생성용 이미지 체크 로직을 수정에도 공통으로 사용하면서, 예외 케이스들이 발생함에 따라 분리 처리 필요
    - 게시글 등록 시, 사용자에게 이미지 2장 이상 첨부하도록 UX를 명확히 전달
    - 게시글 수정 시, 텍스트만 수정하는 경우도 있어 이미지 유효성 검사 로직을 유연하게 처리
    - `@RequestParam` 누락 시 발생하던 서버 예외를 방지
    - 실시간 이미지 수 확인으로 사용자 피드백을 빠르게 제공
    - 중복된 JS 로직을 통합 및 정리하여 유지보수성 향상

---

## 영향 범위

- `post.js` 전체 구조 수정 및 `checkImageCount`, `fileCheck`, `fileUpload` 함수 개선
- `PostApiController`, `updatePost` API 수정 (`imagesToDelete` optional 처리)
- `create.html`, `update.html` 파일 업로드 input 및 경고 영역 처리 개선

---

## 테스트

- ✅ 이미지 첨부 1장 상태에서 등록 → 실패 메시지 출력
- ✅ 이미지 전체 삭제 + 첨부 없음 상태에서 수정 → 실패 메시지 출력
- ✅ 기존 이미지 2장 + 첨부 없음 상태에서 텍스트만 수정 → 정상 통과
- ✅ 기존 이미지 1장 삭제 + 첨부 1장 → 총 1장 → 실패 처리
- ✅ 이미지가 2장 이상이면 생성 및 수정 정상 동작
- ✅ 수정 화면에서 `fileUpload(true)` 호출 없이도 `isUpdateMode` 자동 적용 확인