### PR TITLE
chore: kakao API KEY 로컬스토리지 등록 및 pageScripts 수정

### DIFF
--- a/src/main/resources/static/js/location.js
+++ b/src/main/resources/static/js/location.js
@@ -26,7 +26,7 @@ async function getCoordinates(address) {
         const response = await fetch(url + `?query=${encodedAddress}`, {
             method: 'GET',
             headers: {
-                Authorization: `KakaoAK ${KAKAO_API_KEY}`,
+                Authorization: `KakaoAK ${localStorage.getItem('KAKAO_API_KEY')}`,
             },
         });
 

--- a/src/main/resources/templates/layouts/layout.html
+++ b/src/main/resources/templates/layouts/layout.html
@@ -84,8 +84,6 @@
 <th:block th:replace="~{fragments/script-loader :: load('header')}"></th:block>
 <th:block th:replace="~{fragments/script-loader :: load('member')}"></th:block>
 <th:block th:replace="~{fragments/script-loader :: load('post')}"></th:block>
-<th:block th:replace="~{fragments/script-loader :: load('store')}"></th:block>
-<th:block th:replace="~{fragments/script-loader :: load('location')}"></th:block>
 <th:block layout:fragment="pageScripts"></th:block>
 
 </body>

--- a/src/main/resources/templates/views/stores/create.html
+++ b/src/main/resources/templates/views/stores/create.html
@@ -69,8 +69,10 @@
 
 <th:block layout:fragment="pageScripts">
     <script th:inline="javascript">
-        window.KAKAO_API_KEY = /*[[${kakaoMapKey}]]*/ '';
+        localStorage.setItem('KAKAO_API_KEY', /*[[${kakaoMapKey}]]*/);
     </script>
     <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+    <th:block th:replace="~{fragments/script-loader :: load('store')}"></th:block>
+    <th:block th:replace="~{fragments/script-loader :: load('location')}"></th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/views/stores/detail.html
+++ b/src/main/resources/templates/views/stores/detail.html
@@ -150,5 +150,7 @@
 <th:block layout:fragment="pageScripts">
     <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <script src="https://dapi.kakao.com/v2/maps/sdk.js?appkey=1038c510f5de135a5c0d54f4f9181ef3&libraries=services"></script>
+    <th:block th:replace="~{fragments/script-loader :: load('store')}"></th:block>
+    <th:block th:replace="~{fragments/script-loader :: load('location')}"></th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/views/stores/list.html
+++ b/src/main/resources/templates/views/stores/list.html
@@ -49,5 +49,6 @@
 </div>
 
 <th:block layout:fragment="pageScripts">
+    <th:block th:replace="~{fragments/script-loader :: load('store')}"></th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/views/stores/update.html
+++ b/src/main/resources/templates/views/stores/update.html
@@ -42,5 +42,7 @@
         window.KAKAO_API_KEY = /*[[${kakaoMapKey}]]*/ '';
     </script>
     <script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+    <th:block th:replace="~{fragments/script-loader :: load('store')}"></th:block>
+    <th:block th:replace="~{fragments/script-loader :: load('location')}"></th:block>
 </th:block>
 </html>


### PR DESCRIPTION
## JS
> - `location.js`
>   - kakao API KEY 로컬스토리지를 사용하여 불러오도록 변경

## HTML
> - `layout`
>    - `layout`의 `store`, `location` js 삭제
> - `store`
>    - 각 스토어 html에 `pageScripts` js 추가