### PR TITLE
 PostImage 도메인  Entity/Repository/Validator  테스트 작성 및 요청 DTO 구조 분리

### DIFF
--- a/src/main/java/kr/co/pinup/postImages/exception/postimage/PostImageUpdateCountException.java
+++ b/src/main/java/kr/co/pinup/postImages/exception/postimage/PostImageUpdateCountException.java
@@ -1,0 +1,29 @@
+package kr.co.pinup.postImages.exception.postimage;
+
+import kr.co.pinup.exception.GlobalCustomException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class PostImageUpdateCountException extends GlobalCustomException {
+
+    private static final String DEFAULT_MESSAGE = "이미지는 최소 2장 이상이어야 합니다.";
+
+    public PostImageUpdateCountException() {
+        this(DEFAULT_MESSAGE);
+    }
+
+    public PostImageUpdateCountException(String message) {
+        super(message);
+    }
+
+    public PostImageUpdateCountException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    protected int getHttpStatusCode() {
+        return HttpStatus.BAD_REQUEST.value();
+    }
+}
+

--- a/src/main/java/kr/co/pinup/postImages/model/dto/CreatePostImageRequest.java
+++ b/src/main/java/kr/co/pinup/postImages/model/dto/CreatePostImageRequest.java
@@ -1,5 +1,7 @@
 package kr.co.pinup.postImages.model.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,12 +10,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PostImageRequest {
+public class CreatePostImageRequest {
+    @NotEmpty(message = "이미지는 필수입니다.")
+    @Size(min = 2, max = 5, message = "이미지는 최소 2장 이상, 최대 5장까지 등록 가능합니다.")
     private List<MultipartFile> images;
-    private List<String> imagesToDelete;
 }

--- a/src/main/java/kr/co/pinup/postImages/model/dto/CreatePostImageRequest.java
+++ b/src/main/java/kr/co/pinup/postImages/model/dto/CreatePostImageRequest.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreatePostImageRequest {
+public class CreatePostImageRequest implements PostImageUploadRequest {
     @NotEmpty(message = "이미지는 필수입니다.")
     @Size(min = 2, max = 5, message = "이미지는 최소 2장 이상, 최대 5장까지 등록 가능합니다.")
     private List<MultipartFile> images;

--- a/src/main/java/kr/co/pinup/postImages/model/dto/PostImageUploadRequest.java
+++ b/src/main/java/kr/co/pinup/postImages/model/dto/PostImageUploadRequest.java
@@ -1,0 +1,9 @@
+package kr.co.pinup.postImages.model.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface PostImageUploadRequest {
+    List<MultipartFile> getImages();
+}

--- a/src/main/java/kr/co/pinup/postImages/model/dto/UpdatePostImageRequest.java
+++ b/src/main/java/kr/co/pinup/postImages/model/dto/UpdatePostImageRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class UpdatePostImageRequest {
+public class UpdatePostImageRequest implements PostImageUploadRequest {
     private List<MultipartFile> images;
     private List<String> imagesToDelete;
 }

--- a/src/main/java/kr/co/pinup/postImages/model/dto/UpdatePostImageRequest.java
+++ b/src/main/java/kr/co/pinup/postImages/model/dto/UpdatePostImageRequest.java
@@ -1,0 +1,18 @@
+package kr.co.pinup.postImages.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePostImageRequest {
+    private List<MultipartFile> images;
+    private List<String> imagesToDelete;
+}

--- a/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
+++ b/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
@@ -7,8 +7,9 @@ import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageDeleteFailedException;
 import kr.co.pinup.postImages.exception.postimage.PostImageNotFoundException;
 import kr.co.pinup.postImages.exception.postimage.PostImageSaveFailedException;
-import kr.co.pinup.postImages.model.dto.PostImageRequest;
 import kr.co.pinup.postImages.model.dto.PostImageResponse;
+import kr.co.pinup.postImages.model.dto.PostImageUploadRequest;
+import kr.co.pinup.postImages.model.dto.UpdatePostImageRequest;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.posts.Post;
 import lombok.RequiredArgsConstructor;
@@ -30,12 +31,12 @@ public class PostImageService  {
     private static final String PATH_PREFIX = "post";
 
     @Transactional
-    public List<PostImage> savePostImages(PostImageRequest postImageRequest, Post post) {
-        if (postImageRequest.getImages() == null || postImageRequest.getImages().isEmpty()) {
+    public List<PostImage> savePostImages(PostImageUploadRequest postImageUploadRequest, Post post) {
+        if (postImageUploadRequest.getImages() == null || postImageUploadRequest.getImages().isEmpty()) {
             throw new PostImageNotFoundException("업로드할 이미지가 없습니다.");
         }
 
-        List<String> imageUrls = uploadFiles(postImageRequest.getImages(),PATH_PREFIX);
+        List<String> imageUrls = uploadFiles(postImageUploadRequest.getImages(),PATH_PREFIX);
 
         List<PostImage> postImages = imageUrls.stream()
                 .map(s3Url -> new PostImage(post, s3Url))
@@ -69,8 +70,8 @@ public class PostImageService  {
         }
     }
 
-    public void deleteSelectedImages(Long postId, PostImageRequest postImageRequest) {
-        List<String> imagesToDelete = postImageRequest.getImagesToDelete();
+    public void deleteSelectedImages(Long postId, UpdatePostImageRequest updatePostImageRequest) {
+        List<String> imagesToDelete = updatePostImageRequest.getImagesToDelete();
 
         if (imagesToDelete != null && !imagesToDelete.isEmpty()) {
             List<PostImage> postImages = postImageRepository.findByPostIdAndS3UrlIn(postId, imagesToDelete);

--- a/src/test/java/kr/co/pinup/postImages/PostImageEntityTest.java
+++ b/src/test/java/kr/co/pinup/postImages/PostImageEntityTest.java
@@ -1,0 +1,196 @@
+package kr.co.pinup.postImages;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.pinup.locations.Location;
+import kr.co.pinup.locations.reposiotry.LocationRepository;
+import kr.co.pinup.members.Member;
+import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.members.repository.MemberRepository;
+import kr.co.pinup.oauth.OAuthProvider;
+import kr.co.pinup.postImages.repository.PostImageRepository;
+import kr.co.pinup.posts.Post;
+import kr.co.pinup.posts.repository.PostRepository;
+import kr.co.pinup.store_categories.StoreCategory;
+import kr.co.pinup.store_categories.repository.StoreCategoryRepository;
+import kr.co.pinup.stores.Store;
+import kr.co.pinup.stores.model.enums.Status;
+import kr.co.pinup.stores.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@DataJpaTest
+class PostImageEntityTest {
+
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    PostImageRepository postImageRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    StoreRepository storeRepository;
+    @Autowired
+    StoreCategoryRepository storeCategoryRepository;
+    @Autowired
+    LocationRepository locationRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    Store store;
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        StoreCategory category = storeCategoryRepository.save(new StoreCategory("카테고리 이름"));
+        Location location = locationRepository.save(new Location("지역", "12345", "서울", "강남", 37.0, 127.0, "주소", "상세주소"));
+
+        member = memberRepository.save(Member.builder()
+                .email("test@sample.com")
+                .nickname("테스터")
+                .name("홍길동")
+                .providerId("1234")
+                .providerType(OAuthProvider.NAVER)
+                .role(MemberRole.ROLE_USER)
+                .build());
+
+        store = storeRepository.save(Store.builder()
+                .name("테스트 스토어")
+                .description("설명")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(10))
+                .status(Status.RESOLVED)
+                .imageUrl("http://image")
+                .category(category)
+                .location(location)
+                .build());
+    }
+
+    @Test
+    @DisplayName("PostImage는 Post와 연관되어 저장되어야 한다")
+    void postImage_shouldBeSavedWithPost() {
+        // given
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .store(store)
+                .member(member)
+                .build();
+        postRepository.save(post);
+
+        PostImage postImage = PostImage.builder()
+                .s3Url("https://image.png")
+                .post(post)
+                .build();
+
+        // when
+        postImageRepository.save(postImage);
+        em.flush(); em.clear();
+
+        // then
+        PostImage saved = postImageRepository.findById(postImage.getId()).orElseThrow();
+        assertThat(saved.getS3Url()).isEqualTo("https://image.png");
+        assertThat(saved.getPost().getId()).isEqualTo(post.getId());
+    }
+
+    @Test
+    @DisplayName("Post 없이 저장하면 예외가 발생한다")
+    void shouldFail_whenPostIsNull() {
+        // given
+        PostImage postImage = PostImage.builder()
+                .s3Url("https://image.png")
+                .post(null) // ❌ 연관 Post 없음
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> postImageRepository.save(postImage))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("s3Url 없이 저장하면 예외가 발생한다")
+    void shouldFail_whenS3UrlIsNull() {
+        // given
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .store(store)
+                .member(member)
+                .build();
+        postRepository.save(post);
+
+        PostImage postImage = PostImage.builder()
+                .post(post)
+                .s3Url(null)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> postImageRepository.save(postImage))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("Post 저장 시 PostImage도 함께 저장된다 (Cascade)")
+    void postImage_shouldBeCascadedWithPost() {
+        // given
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .store(store)
+                .member(member)
+                .postImages(new ArrayList<>())
+                .build();
+
+        PostImage img1 = PostImage.builder().s3Url("a.png").post(post).build();
+        PostImage img2 = PostImage.builder().s3Url("b.png").post(post).build();
+        post.getPostImages().addAll(List.of(img1, img2));
+
+        // when
+        postRepository.save(post);
+        em.flush(); em.clear();
+
+        // then
+        Post saved = postRepository.findById(post.getId()).orElseThrow();
+        assertThat(saved.getPostImages()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Post 삭제 시 연결된 PostImage도 함께 삭제된다")
+    void deletePost_shouldAlsoDeletePostImages() {
+        // given
+        Post post = Post.builder()
+                .title("제목")
+                .content("내용")
+                .store(store)
+                .member(member)
+                .postImages(new ArrayList<>())
+                .build();
+
+        PostImage img1 = PostImage.builder().s3Url("a.png").post(post).build();
+        post.getPostImages().add(img1);
+
+        postRepository.save(post);
+        em.flush(); em.clear();
+
+        // when
+        postRepository.deleteById(post.getId());
+        em.flush(); em.clear();
+
+        // then
+        List<PostImage> images = postImageRepository.findByPostId(post.getId());
+        assertThat(images).isEmpty();
+    }
+
+}

--- a/src/test/java/kr/co/pinup/postImages/PostImageRepositoryTest.java
+++ b/src/test/java/kr/co/pinup/postImages/PostImageRepositoryTest.java
@@ -1,0 +1,138 @@
+package kr.co.pinup.postImages;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.pinup.locations.Location;
+import kr.co.pinup.locations.reposiotry.LocationRepository;
+import kr.co.pinup.members.Member;
+import kr.co.pinup.members.model.enums.MemberRole;
+import kr.co.pinup.members.repository.MemberRepository;
+import kr.co.pinup.oauth.OAuthProvider;
+import kr.co.pinup.postImages.repository.PostImageRepository;
+import kr.co.pinup.posts.Post;
+import kr.co.pinup.posts.repository.PostRepository;
+import kr.co.pinup.store_categories.StoreCategory;
+import kr.co.pinup.store_categories.repository.StoreCategoryRepository;
+import kr.co.pinup.stores.Store;
+import kr.co.pinup.stores.model.enums.Status;
+import kr.co.pinup.stores.repository.StoreRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@DataJpaTest
+class PostImageRepositoryTest {
+
+    @Autowired PostImageRepository postImageRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired StoreRepository storeRepository;
+    @Autowired StoreCategoryRepository storeCategoryRepository;
+    @Autowired LocationRepository locationRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    Member member;
+    Store store;
+    Post post;
+
+    @BeforeEach
+    void setUp() {
+        StoreCategory category = storeCategoryRepository.save(new StoreCategory("카테고리 이름"));
+        Location location = locationRepository.save(new Location("테스트 지역", "12345", "서울", "강남구", 37.1234, 127.5678, "서울 강남구 도산대로 123", "101호"));
+
+        member = memberRepository.save(Member.builder()
+                .email("test@sample.com")
+                .name("테스터")
+                .nickname("행복한돼지")
+                .providerType(OAuthProvider.NAVER)
+                .providerId("provider-id-1234")
+                .role(MemberRole.ROLE_USER)
+                .build());
+
+        store = storeRepository.save(Store.builder()
+                .name("테스트 스토어")
+                .description("설명")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(1))
+                .status(Status.RESOLVED)
+                .imageUrl("url")
+                .category(category)
+                .location(location)
+                .build());
+
+        post = postRepository.save(Post.builder()
+                .title("제목")
+                .content("내용")
+                .member(member)
+                .store(store)
+                .build());
+    }
+
+    @Test
+    @DisplayName("게시글 ID로 PostImage 전체 조회")
+    void findByPostIdTest() {
+        // given
+        PostImage img1 = postImageRepository.save(PostImage.builder().post(post).s3Url("a.png").build());
+        PostImage img2 = postImageRepository.save(PostImage.builder().post(post).s3Url("b.png").build());
+
+        // when
+        List<PostImage> result = postImageRepository.findByPostId(post.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("게시글 ID로 PostImage 전체 삭제")
+    void deleteAllByPostIdTest() {
+        // given
+        postImageRepository.save(PostImage.builder().post(post).s3Url("a.png").build());
+        postImageRepository.save(PostImage.builder().post(post).s3Url("b.png").build());
+
+        // when
+        postImageRepository.deleteAllByPostId(post.getId());
+        em.flush(); em.clear();
+
+        // then
+        List<PostImage> result = postImageRepository.findByPostId(post.getId());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("postId + s3Url 리스트 조건으로 PostImage 조회")
+    void findByPostIdAndS3UrlInTest() {
+        // given
+        postImageRepository.save(PostImage.builder().post(post).s3Url("img1.png").build());
+        postImageRepository.save(PostImage.builder().post(post).s3Url("img2.png").build());
+
+        // when
+        List<PostImage> result = postImageRepository.findByPostIdAndS3UrlIn(post.getId(), List.of("img1.png"));
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getS3Url()).isEqualTo("img1.png");
+    }
+
+    @Test
+    @DisplayName("postId 기준 가장 오래된 이미지 조회")
+    void findTopByPostIdOrderByIdAscTest() {
+        // given
+        postImageRepository.save(PostImage.builder().post(post).s3Url("a.png").build());
+        postImageRepository.save(PostImage.builder().post(post).s3Url("b.png").build());
+
+        // when
+        PostImage result = postImageRepository.findTopByPostIdOrderByIdAsc(post.getId());
+
+        // then
+        assertThat(result.getS3Url()).isEqualTo("a.png");
+    }
+}

--- a/src/test/java/kr/co/pinup/postImages/service/PostImageServiceIntegrationTest.java
+++ b/src/test/java/kr/co/pinup/postImages/service/PostImageServiceIntegrationTest.java
@@ -12,8 +12,8 @@ import kr.co.pinup.oauth.OAuthProvider;
 import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageDeleteFailedException;
 import kr.co.pinup.postImages.exception.postimage.PostImageNotFoundException;
-import kr.co.pinup.postImages.model.dto.PostImageRequest;
 import kr.co.pinup.postImages.model.dto.PostImageResponse;
+import kr.co.pinup.postImages.model.dto.UpdatePostImageRequest;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.posts.Post;
 import kr.co.pinup.posts.repository.PostRepository;
@@ -47,26 +47,13 @@ import static org.mockito.Mockito.*;
 @Transactional
 class PostImageServiceIntegrationTest {
 
-    @Autowired
-    private PostImageService postImageService;
-
-    @Autowired
-    private PostImageRepository postImageRepository;
-
-    @Autowired
-    private PostRepository postRepository;
-
-    @Autowired
-    private StoreRepository storeRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private StoreCategoryRepository storeCategoryRepository;
-
-    @Autowired
-    private LocationRepository locationRepository;
+    @Autowired private PostImageService postImageService;
+    @Autowired private PostImageRepository postImageRepository;
+    @Autowired private PostRepository postRepository;
+    @Autowired private StoreRepository storeRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private StoreCategoryRepository storeCategoryRepository;
+    @Autowired private LocationRepository locationRepository;
 
     @Autowired
     private S3Service s3Service;
@@ -181,7 +168,7 @@ class PostImageServiceIntegrationTest {
         PostImage image = postImageRepository.save(new PostImage(post, imageUrl));
         when(s3Service.extractFileName(imageUrl)).thenReturn("img.jpg");
 
-        PostImageRequest request = PostImageRequest.builder()
+        UpdatePostImageRequest request = UpdatePostImageRequest.builder()
                 .imagesToDelete(List.of(imageUrl))
                 .build();
 
@@ -202,7 +189,7 @@ class PostImageServiceIntegrationTest {
         when(s3Service.extractFileName(imageUrl)).thenReturn("img.jpg");
         doThrow(new ImageDeleteFailedException("삭제 실패")).when(s3Service).deleteFromS3("img.jpg");
 
-        PostImageRequest request = PostImageRequest.builder()
+        UpdatePostImageRequest request = UpdatePostImageRequest.builder()
                 .imagesToDelete(List.of(imageUrl))
                 .build();
 
@@ -215,7 +202,7 @@ class PostImageServiceIntegrationTest {
     @DisplayName("선택 이미지 삭제 실패 - 삭제 리스트 없음")
     void deleteSelectedImages_whenEmptyRequest_thenThrowsException() {
         // Given
-        PostImageRequest request = PostImageRequest.builder()
+        UpdatePostImageRequest request = UpdatePostImageRequest.builder()
                 .imagesToDelete(Collections.emptyList())
                 .build();
 

--- a/src/test/java/kr/co/pinup/postImages/service/PostImageServiceUnitTest.java
+++ b/src/test/java/kr/co/pinup/postImages/service/PostImageServiceUnitTest.java
@@ -6,8 +6,10 @@ import kr.co.pinup.members.Member;
 import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageDeleteFailedException;
 import kr.co.pinup.postImages.exception.postimage.PostImageNotFoundException;
-import kr.co.pinup.postImages.model.dto.PostImageRequest;
+
+import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
 import kr.co.pinup.postImages.model.dto.PostImageResponse;
+import kr.co.pinup.postImages.model.dto.UpdatePostImageRequest;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.posts.Post;
 import kr.co.pinup.stores.Store;
@@ -56,7 +58,7 @@ class PostImageServiceUnitTest {
     @DisplayName("이미지 저장 실패 - 이미지가 없는 경우")
     void savePostImages_whenNoImagesProvided_thenThrowsException() {
         // Given
-        PostImageRequest request = PostImageRequest.builder().images(null).build();
+        CreatePostImageRequest request = CreatePostImageRequest.builder().images(null).build();
 
         // When & Then
         assertThrows(PostImageNotFoundException.class,
@@ -113,7 +115,7 @@ class PostImageServiceUnitTest {
     @DisplayName("선택 이미지 삭제 실패 - 삭제 리스트 없음")
     void deleteSelectedImages_whenEmptyRequest_thenThrowsException() {
         // Given
-        PostImageRequest request = PostImageRequest.builder()
+        UpdatePostImageRequest request = UpdatePostImageRequest.builder()
                 .imagesToDelete(Collections.emptyList()).build();
 
         // When & Then
@@ -133,7 +135,7 @@ class PostImageServiceUnitTest {
                 .thenReturn(List.of(img));
         when(s3Service.extractFileName(url)).thenReturn(file);
 
-        PostImageRequest request = PostImageRequest.builder()
+        UpdatePostImageRequest request = UpdatePostImageRequest.builder()
                 .imagesToDelete(List.of(url)).build();
 
         // When
@@ -157,7 +159,7 @@ class PostImageServiceUnitTest {
         when(s3Service.extractFileName(url)).thenReturn(file);
         doThrow(new ImageDeleteFailedException("fail")).when(s3Service).deleteFromS3(file);
 
-        PostImageRequest request = PostImageRequest.builder()
+        UpdatePostImageRequest request = UpdatePostImageRequest.builder()
                 .imagesToDelete(List.of(url)).build();
 
         // When & Then

--- a/src/test/java/kr/co/pinup/postImages/validator/CreatePostImageRequestValidationTest.java
+++ b/src/test/java/kr/co/pinup/postImages/validator/CreatePostImageRequestValidationTest.java
@@ -1,0 +1,88 @@
+package kr.co.pinup.postImages.validator;
+
+import jakarta.validation.*;
+import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CreatePostImageRequestValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("이미지가 null이면 예외 발생")
+    void shouldFail_whenImagesIsNull() {
+        CreatePostImageRequest request = CreatePostImageRequest.builder()
+                .images(null)
+                .build();
+
+        Set<ConstraintViolation<CreatePostImageRequest>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("이미지는 필수입니다."));
+    }
+
+    @Test
+    @DisplayName("이미지가 1장일 경우 예외 발생")
+    void shouldFail_whenImagesLessThanMin() {
+        MockMultipartFile file = new MockMultipartFile("image", "image1.jpg", "image/jpeg", new byte[1]);
+        CreatePostImageRequest request = CreatePostImageRequest.builder()
+                .images(List.of(file))
+                .build();
+
+        Set<ConstraintViolation<CreatePostImageRequest>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getMessage().contains("최소 2장"));
+    }
+
+    @Test
+    @DisplayName("이미지가 6장일 경우 예외 발생")
+    void shouldFail_whenImagesExceedMax() {
+        List<MultipartFile> images = List.of(
+                mockImage(), mockImage(), mockImage(),
+                mockImage(), mockImage(), mockImage() // 6장
+        );
+
+        CreatePostImageRequest request = CreatePostImageRequest.builder()
+                .images(images)
+                .build();
+
+        Set<ConstraintViolation<CreatePostImageRequest>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getMessage().contains("최대 5장"));
+    }
+
+    @Test
+    @DisplayName("이미지가 2~5장일 경우 통과")
+    void shouldPass_whenImagesAreValid() {
+        List<MultipartFile> images = List.of(
+                mockImage(), mockImage()
+        );
+
+        CreatePostImageRequest request = CreatePostImageRequest.builder()
+                .images(images)
+                .build();
+
+        Set<ConstraintViolation<CreatePostImageRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    private MockMultipartFile mockImage() {
+        return new MockMultipartFile("image", "test.jpg", "image/jpeg", new byte[10]);
+    }
+}
+

--- a/src/test/java/kr/co/pinup/postImages/validator/UpdatePostImageRequestValidatorTest.java
+++ b/src/test/java/kr/co/pinup/postImages/validator/UpdatePostImageRequestValidatorTest.java
@@ -1,0 +1,57 @@
+package kr.co.pinup.postImages.validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class UpdatePostImageRequestValidatorTest {
+    private List<String> existingImages;
+
+    @BeforeEach
+    void setUp() {
+        existingImages = new ArrayList<>(List.of(
+                "img1.png", "img2.png", "img3.png"
+        ));
+    }
+
+    private boolean isValid(List<String> imagesToDelete, List<MultipartFile> newImages) {
+        int deletedCount = (imagesToDelete != null) ? imagesToDelete.size() : 0;
+        int addedCount = (newImages != null) ? (int) newImages.stream().filter(f -> !f.isEmpty()).count() : 0;
+
+        int remaining = existingImages.size() - deletedCount + addedCount;
+        return remaining >= 2;
+    }
+
+    @Test
+    @DisplayName("삭제 + 추가 이미지 조합 결과가 2장 이상이면 검증 통과")
+    void shouldPass_whenRemainingImagesAreTwoOrMore() {
+        // given
+        List<String> toDelete = List.of("img1.png");
+        List<MultipartFile> newImages = List.of(mockFile("new1.png"));
+
+        // expect
+        assertThat(isValid(toDelete, newImages)).isTrue();
+    }
+
+    @Test
+    @DisplayName("삭제 + 추가 이미지 조합 결과가 2장 미만이면 검증 실패")
+    void shouldFail_whenRemainingImagesAreLessThanTwo() {
+        // given
+        List<String> toDelete = List.of("img1.png", "img2.png", "img3.png");
+        List<MultipartFile> newImages = List.of();
+
+        // expect
+        assertThat(isValid(toDelete, newImages)).isFalse();
+    }
+
+    private MultipartFile mockFile(String name) {
+        return new MockMultipartFile("images", name, "image/png", new byte[10]);
+    }
+}


### PR DESCRIPTION
## 변경 사항

1. **PostImage 테스트 코드 작성**
    - `PostImageEntityTest`: 필수 필드 누락 시 예외 발생, Post 연관 저장 테스트 포함
        - 연관된 `Post`가 **Lazy 로딩** 되는지 확인하는 테스트 추가
    - `PostImageRepositoryTest`: 기본 쿼리 메서드 (`findByPostId`, `deleteAllByPostId`) 동작 검증
2. **PostImage 요청 DTO 분리 및 리팩토링**
    - 기존 통합형 `PostImageRequest` → `CreatePostImageRequest`, `UpdatePostImageRequest` 로 분리
    - 공통 인터페이스 `PostImageUploadRequest` 도입
        - `getImages()` 메서드를 통해 이미지 리스트 접근 가능
        - `savePostImages()` 등의 서비스 메서드에서 인터페이스 기반으로 공통 처리 가능
    - 이미지 업로드 목적(생성 vs 수정)에 따라 구조 명확화
3. **Validator 테스트 클래스 추가**
    - `CreatePostImageRequestValidationTest`
        - 이미지가 `null`, 1장, 6장 등 유효하지 않은 경우 예외 검증
        - 2~5장 입력 시 정상 통과 확인
    - `UpdatePostImageRequestValidatorTest`
        - 기존 이미지 수에서 삭제 + 추가 이미지 수를 조합하여 남은 이미지가 최소 2장 이상이어야 통과
4. **커스텀 예외 처리 도입**
    - `PostImageUpdateCountException` 클래스 생성
    - 이미지가 2장 미만으로 줄어들 경우, 명시적 예외 발생 처리를 위해 사용
5. **PostImageService 로직 리팩토링**
    - `savePostImages()` 등의 메서드에서 DTO 클래스가 아닌 `PostImageUploadRequest` 인터페이스 기반으로 처리되도록 변경
    - 서비스 내 공통 로직 재사용성과 테스트 용이성 향상
6. **테스트 디렉토리 구조 개선**
    - `postImages/validator/` 하위로 Validator 관련 테스트 클래스 구조 정리

---

## 변경 이유

- PostImage 관련 로직의 테스트 커버리지를 확보하여 안정성 강화
- 생성/수정 시 요청 목적이 달라, 하나의 DTO(`PostImageRequest`)로 처리하기에는 한계 존재 → 명확히 분리
- 비즈니스 요구사항상 이미지 최소 2장 조건을 보장하기 위해 유효성 검증 로직을 별도 테스트 및 예외 처리로 관리
- DTO를 인터페이스로 추상화하여 중복 제거 및 서비스 코드 유연성 확보
- Lazy 로딩 동작 보장을 위한 단위 테스트 확보

---

## 영향 범위

- `postImages` 도메인 내 테스트 및 예외 처리 구조 개선
- PostImage 관련 DTO 구조가 변경되었으며, 기존 `PostImageRequest`는 제거됨
- `PostImageService`는 더 이상 특정 DTO 타입에 의존하지 않음 (인터페이스 기반 처리)
- Post 도메인의 Service/Controller에서 해당 변경을 적용하는 작업은 별도 브랜치에서 이어질 예정

---

## 추가 사항

- PostService의 `updatePost()` 내부에 이미지 최소 개수 유효성 검증 로직이 도입될 예정이며, 해당 로직은 `PostImageUpdateCountException`을 활용해 처리될 예정
- PostApiController의 `createPost()` 파라미터는 추후 `@ModelAttribute @Valid CreatePostImageRequest` 형태로 수정 예정
- 기존 `PostImageRequest`를 사용하는 모든 로직은 향후 분리된 DTO 구조 및 공통 인터페이스에 맞게 정리될 예정

---

## 참고 사항

- 본 PR은 postImages 도메인의 테스트 및 유효성 검증 구조 개선을 목적으로 하며, 이후 post 도메인에서 해당 변경을 반영하는 브랜치 작업이 진행될 예정입니다