### PR TITLE
chore: actions github ip ssh 추가, 제거 작업 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -313,6 +313,15 @@ jobs:
             tags: pinup0106/pinup:${{ steps.extract_version.outputs.version }}
             labels: version=${{ steps.extract_version.outputs.version }}
 
+        - name: Get GitHub IP
+          id: ip
+          run: |
+            echo "ipv4=$(curl -s https://api.ipify.org)" >> $GITHUB_OUTPUT
+
+        - name: Add GitHub IP to AWS Security Group
+          run: |
+            aws ec2 authorize-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32
+
         - name: Deploy to EC2
           uses: appleboy/ssh-action@v1.0.3
           with:
@@ -324,3 +333,7 @@ jobs:
               docker stop pinup-container || true
               docker rm pinup-container || true
               docker run -d --name pinup-container -p 80:8080 pinup0106/pinup:latest
+
+        - name: Remove IP FROM Security Group
+          run: |
+            aws ec2 revoke-security-group-ingress --group-id ${{ secrets.AWS_SG_ID }} --protocol tcp --port 22 --cidr ${{ steps.ip.outputs.ipv4 }}/32


### PR DESCRIPTION
## 요약
actions에 github ip로 ssh 접근 허용 룰 추가 및 완료 후 다시 제거

## 작업 내용
- actions에 github ip로 ssh 접근 허용 룰 추가 및 완료 후 다시 제거

## 참고 사항

## 관련 이슈

- Close #이슈번호