### PR TITLE
feat: 필요한 데이터들 로그 기록

### DIFF
--- a/src/main/java/kr/co/pinup/api/aws/AwsSecretsManagerProvider.java
+++ b/src/main/java/kr/co/pinup/api/aws/AwsSecretsManagerProvider.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import kr.co.pinup.api.aws.exception.SecretsManagerFetchException;
 import kr.co.pinup.api.kakao.model.dto.KakaoSecret;
 import kr.co.pinup.config.AwsSecretsProperties;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
@@ -12,6 +13,7 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class AwsSecretsManagerProvider implements AwsSecretsProvider {
 
     private static final String KAKAO_API_REST_KEY = "kakao.api.key.rest";
@@ -20,16 +22,6 @@ public class AwsSecretsManagerProvider implements AwsSecretsProvider {
     private final ObjectMapper objectMapper;
     private final AwsSecretsProperties secretsProperties;
     private final SecretsManagerClientFactory secretsManagerClientFactory;
-
-    public AwsSecretsManagerProvider(
-            final ObjectMapper objectMapper,
-            final AwsSecretsProperties secretsProperties,
-            final SecretsManagerClientFactory secretsManagerClientFactory
-    ) {
-        this.objectMapper = objectMapper;
-        this.secretsProperties = secretsProperties;
-        this.secretsManagerClientFactory = secretsManagerClientFactory;
-    }
 
     @Override
     public String getSecretValue(final String secretKey) {
@@ -41,7 +33,7 @@ public class AwsSecretsManagerProvider implements AwsSecretsProvider {
             ).secretString();
 
             final KakaoSecret kakaoSecret = objectMapper.readValue(secret, KakaoSecret.class);
-            log.debug("AwsSecretsManagerProvider.getSecretValue kakaoSecret={}", kakaoSecret);
+            log.debug("getSecretValue method kakaoSecret={}", kakaoSecret);
 
             return switch (secretKey) {
                 case KAKAO_API_REST_KEY -> kakaoSecret.restApiKey();

--- a/src/main/java/kr/co/pinup/api/kakao/KakaoApiService.java
+++ b/src/main/java/kr/co/pinup/api/kakao/KakaoApiService.java
@@ -1,6 +1,8 @@
 package kr.co.pinup.api.kakao;
 
 import kr.co.pinup.api.kakao.model.dto.KakaoAddressDocument;
+import kr.co.pinup.custom.logging.AppLogger;
+import kr.co.pinup.custom.logging.model.dto.InfoLog;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,9 +12,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class KakaoApiService {
 
+    private final AppLogger logger;
     private final KakaoApiClient kakaoApiClient;
 
     public KakaoAddressDocument searchAddress(String address) {
+        logger.info(new InfoLog("카카오 맵 검색 주소=" + address));
+
         return kakaoApiClient.searchAddress(address);
     }
 }

--- a/src/main/java/kr/co/pinup/exception/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/pinup/exception/GlobalExceptionHandler.java
@@ -72,7 +72,6 @@ public class GlobalExceptionHandler {
                 new WarnLog("멤버 잘못된 요청: " + ex.getMessage())
                         .setStatus(String.valueOf(status))
                         .addDetails("reason", ex.getMessage())
-
         );
 
         ErrorResponse errorResponse = ErrorResponse.builder()
@@ -92,7 +91,6 @@ public class GlobalExceptionHandler {
         appLogger.error(
                 new ErrorLog("접근 거부", ex)
                         .setStatus(String.valueOf(status))
-
         );
 
         model.addAttribute("error", ErrorResponse.builder()
@@ -111,7 +109,6 @@ public class GlobalExceptionHandler {
         appLogger.warn(
                 new WarnLog("OAuth 로그인 취소")
                         .setStatus(String.valueOf(status))
-
         );
 
         return "index";
@@ -120,10 +117,16 @@ public class GlobalExceptionHandler {
     @ResponseBody
     @ExceptionHandler(KakaoApiException.class)
     public ResponseEntity<ErrorResponse> kakaoApiHandler(KakaoApiException ex) {
-        log.warn("[KakaoApiException] ", ex);
+        final int statusCode = BAD_REQUEST.value();
+
+        appLogger.warn(
+                new WarnLog("Kakao API 예외 발생 " + ex)
+                        .setStatus(String.valueOf(statusCode))
+                        .addDetails("reason", ex.getMessage())
+        );
 
         ErrorResponse errorResponse = ErrorResponse.builder()
-                .status(BAD_REQUEST.value())
+                .status(statusCode)
                 .message(ex.getMessage())
                 .build();
 
@@ -134,10 +137,16 @@ public class GlobalExceptionHandler {
     @ResponseBody
     @ExceptionHandler(SecretsManagerFetchException.class)
     public ResponseEntity<ErrorResponse> secretsManagerFetchHandler(SecretsManagerFetchException ex) {
-        log.error("[SecretsManagerFetchException] ", ex);
+        final int statusCode = INTERNAL_SERVER_ERROR.value();
+
+        appLogger.error(
+                new ErrorLog("SecretsManagerFetch 예외 발생 ", ex)
+                        .setStatus(String.valueOf(statusCode))
+                        .addDetails("validation", ex.getMessage())
+        );
 
         ErrorResponse errorResponse = ErrorResponse.builder()
-                .status(INTERNAL_SERVER_ERROR.value())
+                .status(statusCode)
                 .message(ex.getMessage())
                 .build();
 
@@ -150,10 +159,9 @@ public class GlobalExceptionHandler {
         int status = ex.getHttpStatusCode();
 
         appLogger.error(
-                new ErrorLog("커스텀 예외 발생", ex)
+                new ErrorLog("커스텀 예외 발생 ", ex)
                         .setStatus(String.valueOf(status))
                         .addDetails("validation", ex.getValidation().toString())
-
         );
 
         model.addAttribute("error", ErrorResponse.builder()
@@ -175,7 +183,6 @@ public class GlobalExceptionHandler {
         appLogger.error(
                 new ErrorLog("서버 내부 오류", ex)
                         .setStatus(String.valueOf(status))
-
         );
 
         model.addAttribute("error", ErrorResponse.builder()
@@ -217,7 +224,6 @@ public class GlobalExceptionHandler {
                 new WarnLog("입력값 유효성 오류")
                         .setStatus(String.valueOf(status))
                         .addDetails("reason", "invalid input","invalidFields", errors.toString())
-
         );
 
         ErrorResponse errorResponse = new ErrorResponse(

--- a/src/main/java/kr/co/pinup/faqs/controller/FaqApiController.java
+++ b/src/main/java/kr/co/pinup/faqs/controller/FaqApiController.java
@@ -29,6 +29,8 @@ public class FaqApiController {
     @PostMapping
     public ResponseEntity<Void> save(@AuthenticationPrincipal MemberInfo memberInfo,
                                      @RequestBody @Valid FaqCreateRequest request) {
+        log.debug("save method FaqCreateRequest={}", request);
+
         faqService.save(memberInfo, request);
 
         return ResponseEntity.status(CREATED).build();
@@ -41,12 +43,16 @@ public class FaqApiController {
 
     @GetMapping("/{faqId}")
     public ResponseEntity<FaqResponse> find(@PathVariable Long faqId) {
+        log.debug("find method faqId={}", faqId);
+
         return ResponseEntity.ok(faqService.find(faqId));
     }
 
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @PutMapping("/{faqId}")
     public ResponseEntity<Void> update(@PathVariable Long faqId, @RequestBody @Valid FaqUpdateRequest request) {
+        log.debug("update method faqId={}, FaqUpdateRequest={}", faqId, request);
+
         faqService.update(faqId, request);
 
         return ResponseEntity.noContent().build();
@@ -55,6 +61,8 @@ public class FaqApiController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{faqId}")
     public ResponseEntity<Void> delete(@PathVariable Long faqId) {
+        log.debug("delete method faqId={}", faqId);
+
         faqService.remove(faqId);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/kr/co/pinup/faqs/controller/FaqController.java
+++ b/src/main/java/kr/co/pinup/faqs/controller/FaqController.java
@@ -45,6 +45,8 @@ public class FaqController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @GetMapping("/{faqId}/update")
     public String update(@PathVariable Long faqId, Model model) {
+        log.debug("update method faqId={}", faqId);
+
         model.addAttribute("category", getFaqCategoryToMap());
         model.addAttribute("faq", faqService.find(faqId));
 

--- a/src/main/java/kr/co/pinup/notices/controller/NoticeApiController.java
+++ b/src/main/java/kr/co/pinup/notices/controller/NoticeApiController.java
@@ -32,6 +32,8 @@ public class NoticeApiController {
 
     @GetMapping("/{noticeId}")
     public NoticeResponse find(@PathVariable Long noticeId) {
+        log.debug("find method noticeId={}", noticeId);
+
         return noticeService.find(noticeId);
     }
 
@@ -39,6 +41,8 @@ public class NoticeApiController {
     @PostMapping
     public ResponseEntity<Void> save(@AuthenticationPrincipal MemberInfo memberInfo,
                                      @RequestBody @Valid NoticeCreateRequest request) {
+        log.debug("save method NoticeCreateRequest={}", request);
+
         noticeService.save(memberInfo, request);
 
         return ResponseEntity.status(CREATED).build();
@@ -47,6 +51,8 @@ public class NoticeApiController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @PutMapping("/{noticeId}")
     public ResponseEntity<Void> update(@PathVariable Long noticeId, @RequestBody @Valid NoticeUpdateRequest request) {
+        log.debug("update method noticeId={}, NoticeUpdateRequest={}", noticeId, request);
+
         noticeService.update(noticeId, request);
 
         return ResponseEntity.noContent().build();
@@ -55,6 +61,8 @@ public class NoticeApiController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{noticeId}")
     public ResponseEntity<Void> delete(@PathVariable Long noticeId) {
+        log.debug("delete method noticeId={}", noticeId);
+
         noticeService.remove(noticeId);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/kr/co/pinup/notices/controller/NoticeController.java
+++ b/src/main/java/kr/co/pinup/notices/controller/NoticeController.java
@@ -35,6 +35,8 @@ public class NoticeController {
 
     @GetMapping("/{noticeId}")
     public String detail(@PathVariable Long noticeId, Model model) {
+        log.debug("detail method noticeId={}", noticeId);
+
         model.addAttribute("notice", noticeService.find(noticeId));
 
         return VIEW_PATH + "/detail";
@@ -43,6 +45,8 @@ public class NoticeController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_ADMIN')")
     @GetMapping("/{noticeId}/update")
     public String update(@PathVariable Long noticeId, Model model) {
+        log.debug("update method noticeId={}", noticeId);
+
         model.addAttribute("notice", noticeService.find(noticeId));
 
         return VIEW_PATH + "/update";

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,8 +5,8 @@
     <conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter"/>
 
     <property name="USER_HOME" value="${user.home}"/>
-    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}){} %clr(${PID:-}){magenta} %clr(--- %esb(){APPLICATION_NAME}%esb{APPLICATION_GROUP}[%15.15t] ${LOG_CORRELATION_PATTERN:-}){faint} %clr(%replace(%X{requestId}){'.+','[$0]'}){magenta} %clr(%replace(%X{nickname}){'.+','[$0]'}){magenta} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
-    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%-5level) %replace(%X{requestId}){'.+','[$0]'} %replace(%X{nickname}){'.+','[$0]'} %logger{36} - %msg%n"/>
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd'T'HH:mm:ss.SSSXXX}}){faint} %clr(${LOG_LEVEL_PATTERN:-%5p}){} %clr(${PID:-}){magenta} %clr(--- %esb(){APPLICATION_NAME}%esb{APPLICATION_GROUP}[%15.15t] ${LOG_CORRELATION_PATTERN:-}){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %clr(%-5level) %replace(%X{requestId}){'.+','[$0]'} %replace(%X{className}){'.+','[$0]'} %replace(%X{methodName}){'.+','[$0]'} %replace(%X{targetId}){'.+','[$0]'} %replace(%X{userNickName}){'.+','[$0]'} %logger{36} - %msg%n"/>
 
     <springProperty name="AWS_ACCESS_KEY" source="cloud.aws.credentials.accessKey"/>
     <springProperty name="AWS_SECRET_KEY" source="cloud.aws.credentials.secretKey"/>

--- a/src/test/java/kr/co/pinup/api/kakao/KakaoApiServiceTest.java
+++ b/src/test/java/kr/co/pinup/api/kakao/KakaoApiServiceTest.java
@@ -2,6 +2,7 @@ package kr.co.pinup.api.kakao;
 
 import kr.co.pinup.api.kakao.exception.KakaoApiException;
 import kr.co.pinup.api.kakao.model.dto.KakaoAddressDocument;
+import kr.co.pinup.custom.logging.AppLogger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,9 @@ class KakaoApiServiceTest {
 
     @Mock
     private KakaoApiClient kakaoApiClient;
+
+    @Mock
+    private AppLogger logger;
 
     @InjectMocks
     private KakaoApiService kakaoApiService;


### PR DESCRIPTION
## 요약
- 로그 추적을 위한 필요한 데이터들 로그 기록
- 로그 구현 클래스로 중요한 로그들 지정
- logback 파일 출력에 MDC 목록들 전부 추가

## 작업 내용
- 고객센터 도메인들은 구현이 간단하고 요청 횟수가 적을 것 같아 컨트롤러에 debug로 데이터 로그 기록
- ExceptionHandler에 SecretsManager, Kakao API에 대한 로그 구현 클래스로 로그 기록
- Kakao API 서비스에 검색 주소명 로그 구현 클래스로 로그 기록
- logback 파일 출력에 MDC 빠진 목록들 추가

## 참고 사항

## 관련 이슈

- Close #이슈번호