### PR TITLE
feat:Post 도메인 구조화 로깅(AppLogger) 적용 및 컨트롤러 DEBUG 로그 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = 'kr.co'
-version = '1.0.1'
+version = '1.0.2'
 
 java {
 	toolchain {

--- a/src/main/java/kr/co/pinup/posts/controller/PostController.java
+++ b/src/main/java/kr/co/pinup/posts/controller/PostController.java
@@ -30,6 +30,7 @@ public class PostController {
 
     @GetMapping("/list/{storeId}")
     public String getAllPosts(@PathVariable @Positive Long storeId, Model model) {
+        log.debug("게시글 목록 뷰 진입: storeId={}", storeId);
         model.addAttribute("posts", postService.findByStoreIdWithCommentCount(storeId,false));
         model.addAttribute("storeId", storeId);
         return VIEW_PATH + "/list";
@@ -37,6 +38,7 @@ public class PostController {
 
     @GetMapping("/{postId}")
     public String getPostById(@PathVariable @Positive Long postId, Model model) {
+        log.debug("게시글 상세 뷰 진입: postId={}", postId);
         model.addAttribute("post", postService.getPostById(postId,false));
         model.addAttribute("comments", commentService.findByPostId(postId));
         model.addAttribute("images", postImageService.findImagesByPostId(postId));
@@ -46,6 +48,7 @@ public class PostController {
     @PreAuthorize("isAuthenticated() and (hasRole('ROLE_USER') or hasRole('ROLE_ADMIN'))")
     @GetMapping("/create")
     public String createPostForm(@RequestParam("storeId") @Positive Long storeId, Model model) {
+        log.debug("게시글 작성 폼 진입: storeId={}", storeId);
         model.addAttribute("storeId", storeId);
         return VIEW_PATH + "/create";
     }
@@ -53,6 +56,7 @@ public class PostController {
     @PreAuthorize("isAuthenticated() and (hasRole('ROLE_USER') or hasRole('ROLE_ADMIN'))")
     @GetMapping("/update/{postId}")
     public String updatePostForm(@PathVariable @Positive Long postId, Model model) {
+        log.debug("게시글 수정 폼 진입: postId={}", postId);
         model.addAttribute("post", postService.getPostById(postId,false));
         model.addAttribute("images", postImageService.findImagesByPostId(postId));
         return VIEW_PATH + "/update";

--- a/src/test/java/kr/co/pinup/posts/service/PostServiceUnitTest.java
+++ b/src/test/java/kr/co/pinup/posts/service/PostServiceUnitTest.java
@@ -1,5 +1,6 @@
 package kr.co.pinup.posts.service;
 
+import kr.co.pinup.custom.logging.AppLogger;
 import kr.co.pinup.locations.Location;
 import kr.co.pinup.members.Member;
 import kr.co.pinup.members.exception.MemberNotFoundException;
@@ -33,6 +34,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -47,9 +49,6 @@ import static org.mockito.Mockito.*;
 public class
 PostServiceUnitTest {
 
-    @InjectMocks
-    private PostService postService;
-
     @Mock
     private PostRepository postRepository;
     @Mock
@@ -58,6 +57,11 @@ PostServiceUnitTest {
     private MemberRepository memberRepository;
     @Mock
     private StoreRepository storeRepository;
+    @Mock
+    private AppLogger appLogger;
+
+    @InjectMocks
+    private PostService postService;
 
     private Member member;
     private Store store;
@@ -100,6 +104,7 @@ PostServiceUnitTest {
             );
             CreatePostImageRequest imageReq = CreatePostImageRequest.builder().images(validFiles).build();
             Post post = Post.builder().store(store).member(member).title(req.title()).content(req.content()).build();
+            ReflectionTestUtils.setField(post, "id", 1L);
 
             when(memberRepository.findByNickname("행복한돼지")).thenReturn(Optional.of(member));
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
@@ -158,13 +163,17 @@ PostServiceUnitTest {
 
             when(memberRepository.findByNickname("행복한돼지")).thenReturn(Optional.of(member));
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
-            when(postRepository.save(any(Post.class))).thenReturn(Post.builder().store(store).member(member).title("제목").content("내용").build());
+
+            Post post = Post.builder().store(store).member(member).title("제목").content("내용").build();
+            ReflectionTestUtils.setField(post, "id", 1L);
+            when(postRepository.save(any(Post.class))).thenReturn(post);
 
             when(postImageService.savePostImages(any(), any())).thenThrow(PostImageUpdateCountException.class);
 
             assertThrows(PostImageUpdateCountException.class, () ->
                     postService.createPost(memberInfo, req, imageReq));
         }
+
 
         @Test
         @DisplayName("게시물 생성 - 이미지 저장 호출 확인")
@@ -178,6 +187,7 @@ PostServiceUnitTest {
             CreatePostImageRequest imageReq = CreatePostImageRequest.builder().images(files).build();
 
             Post post = Post.builder().store(store).member(member).title("제목").content("내용").build();
+            ReflectionTestUtils.setField(post, "id", 1L);
 
             when(memberRepository.findByNickname("행복한돼지")).thenReturn(Optional.of(member));
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));
@@ -200,6 +210,7 @@ PostServiceUnitTest {
             CreatePostImageRequest imageReq = CreatePostImageRequest.builder().images(files).build();
 
             Post post = Post.builder().store(store).member(member).title("제목").content("내용").build();
+            ReflectionTestUtils.setField(post, "id", 1L);
 
             when(memberRepository.findByNickname("행복한돼지")).thenReturn(Optional.of(member));
             when(storeRepository.findById(1L)).thenReturn(Optional.of(store));


### PR DESCRIPTION
## 요약

Post 도메인에 대해 구조화 로깅 시스템(AppLogger) 기반의 로깅을 적용하고, 요청 흐름 파악을 위한 DEBUG 로그를 각 컨트롤러에 추가했습니다.  
또한 PostServiceUnitTest에서 발생한 NullPointerException을 방지하기 위해 테스트 코드를 보완했습니다.

---

## 작업 내용

- `PostService`
    - `AppLogger` 기반 구조화 로그 (`InfoLog`, `WarnLog`, `ErrorLog`) 적용
    - 예외, 상태 코드, 주요 식별자 포함한 일관된 로깅 체계 확립

- `PostApiController`, `PostController`
    - 진입 시점 `DEBUG` 로그 삽입 (`Slf4j`)
    - API 흐름 추적 및 디버깅 용도

- `PostServiceUnitTest`
    - `@Mock AppLogger` 추가 및 생성자에 주입
    - 테스트 시 `post.getId()` 호출로 인한 `NullPointerException` 방지를 위해 ID 수동 설정

- `build.gradle`
    - 로깅 관련 의존성 및 설정 반영

---

## 참고 사항

- 컨트롤러에서는 `AppLogger`가 아닌 `Slf4j`의 `log.debug`만 사용했습니다.
- 로그 출력은 JSON 기반 구조화 포맷으로 적용됨 (운영 분석에 용이)
- 테스트 환경에서 Spring Data JPA의 save()는 실제 DB flush 이전까지 ID를 할당하지 않으므로, 단위 테스트 시 수동 ID 설정이 필요합니다.
- Mockito 기반 테스트에서는 외부 의존성(AppLogger 등)을 명시적으로 모킹해야 함

---

## 관련 이슈

- Close #이슈번호
