### PR TITLE
feat: PostImages 및 S3 도메인 AppLogger 구조화 로깅 도입 및 테스트 개선

### DIFF
--- a/src/main/java/kr/co/pinup/config/S3Config.java
+++ b/src/main/java/kr/co/pinup/config/S3Config.java
@@ -1,5 +1,9 @@
 package kr.co.pinup.config;
 
+import kr.co.pinup.custom.logging.AppLogger;
+import kr.co.pinup.custom.logging.model.dto.ErrorLog;
+import kr.co.pinup.custom.logging.model.dto.InfoLog;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +17,10 @@ import java.net.URI;
 import java.time.Duration;
 
 @Configuration
+@RequiredArgsConstructor
 public class S3Config {
+
+    private final AppLogger appLogger;
 
     @Value("${cloud.aws.credentials.accessKey}")
     String accessKey;
@@ -32,21 +39,33 @@ public class S3Config {
 
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
-        if (endpoint != null && !endpoint.isEmpty()) {
+        try {
+            if (endpoint != null && !endpoint.isEmpty()) {
+                appLogger.info(new InfoLog("S3Client 생성 - 커스텀 엔드포인트 사용")
+                        .addDetails("endpoint", endpoint));
+                return S3Client.builder()
+                        .endpointOverride(URI.create(endpoint))
+                        .region(Region.US_EAST_1)
+                        .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                        .overrideConfiguration(ClientOverrideConfiguration.builder()
+                                .apiCallTimeout(Duration.ofMinutes(2))
+                                .apiCallAttemptTimeout(Duration.ofSeconds(30))
+                                .build())
+                        .build();
+            }
+            appLogger.info(new InfoLog("S3Client 생성 - 기본 리전 사용")
+                    .addDetails("region", region));
             return S3Client.builder()
-                    .endpointOverride(URI.create(endpoint))
-                    .region(Region.US_EAST_1)
+                    .region(Region.of(region))
                     .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                    .overrideConfiguration(ClientOverrideConfiguration.builder()
-                            .apiCallTimeout(Duration.ofMinutes(2))
-                            .apiCallAttemptTimeout(Duration.ofSeconds(30))
-                            .build())
                     .build();
-        }
 
-        return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
-                .build();
+        } catch (Exception e) {
+            appLogger.error(new ErrorLog("S3Client 생성 실패", e)
+                    .setStatus("500")
+                    .addDetails("endpoint", endpoint)
+                    .addDetails("region", region));
+            throw e;
+        }
     }
 }

--- a/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
+++ b/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
@@ -1,6 +1,10 @@
 package kr.co.pinup.postImages.service;
 
 import jakarta.transaction.Transactional;
+import kr.co.pinup.custom.logging.AppLogger;
+import kr.co.pinup.custom.logging.model.dto.ErrorLog;
+import kr.co.pinup.custom.logging.model.dto.InfoLog;
+import kr.co.pinup.custom.logging.model.dto.WarnLog;
 import kr.co.pinup.custom.s3.S3Service;
 import kr.co.pinup.custom.s3.exception.ImageDeleteFailedException;
 import kr.co.pinup.postImages.PostImage;
@@ -27,6 +31,7 @@ public class PostImageService  {
 
     private final S3Service s3Service;
     private final PostImageRepository postImageRepository;
+    private final AppLogger appLogger;
 
     private static final String PATH_PREFIX = "post";
 
@@ -44,7 +49,15 @@ public class PostImageService  {
 
         try {
             postImageRepository.saveAll(postImages);
+            appLogger.info(new InfoLog("이미지 저장 완료")
+                    .setStatus("201")
+                    .setTargetId(post.getId().toString())
+                    .addDetails("count", String.valueOf(postImages.size())));
         } catch (Exception e) {
+            appLogger.error(new ErrorLog("이미지 저장 실패", e)
+                    .setStatus("500")
+                    .setTargetId(post.getId().toString())
+                    .addDetails("reason", e.getMessage()));
             throw new PostImageSaveFailedException("이미지 저장 중 문제가 발생했습니다.", e);
         }
 
@@ -58,14 +71,16 @@ public class PostImageService  {
             return;
         }
         try {
-        postImages.forEach(postImage -> {
-            String fileUrl = postImage.getS3Url();
-            String fileName = PATH_PREFIX+ "/" + s3Service.extractFileName(fileUrl);
+            postImages.forEach(postImage -> {
+                String fileUrl = postImage.getS3Url();
+                String fileName = PATH_PREFIX+ "/" + s3Service.extractFileName(fileUrl);
 
                 s3Service.deleteFromS3(fileName);
-        });
+            });
             postImageRepository.deleteAllByPostId(postId);
+            appLogger.info(new InfoLog("전체 이미지 삭제 완료").setTargetId(postId.toString()));
         } catch (Exception e) {
+            appLogger.error(new ErrorLog("전체 이미지 삭제 실패", e).setStatus("500").setTargetId(postId.toString()).addDetails("reason", e.getMessage()));
             throw new PostImageDeleteFailedException("이미지 삭제 중 문제가 발생했습니다.", e);
         }
     }
@@ -82,16 +97,30 @@ public class PostImageService  {
                 try {
                     s3Service.deleteFromS3(fileName);
                 } catch (ImageDeleteFailedException e) {
+                    appLogger.error(new ErrorLog("S3 이미지 삭제 실패", e)
+                            .setTargetId(postId.toString())
+                            .setStatus("500")
+                            .addDetails("file", fileName));
                     throw new ImageDeleteFailedException("이미지 삭제 중 문제가 발생했습니다.", e);
                 }
             });
 
             try {
                 postImageRepository.deleteAll(postImages);
+                appLogger.info(new InfoLog("선택 이미지 삭제 완료")
+                        .setTargetId(postId.toString())
+                        .addDetails("count", String.valueOf(postImages.size())));
             } catch (Exception e) {
+                appLogger.error(new ErrorLog("DB 이미지 삭제 실패", e)
+                        .setTargetId(postId.toString())
+                        .setStatus("500")
+                        .addDetails("reason", e.getMessage()));
                 throw new PostImageDeleteFailedException("이미지 삭제 중 문제가 발생했습니다.", e);
             }
         } else {
+            appLogger.warn(new WarnLog("삭제 요청 이미지 없음")
+                    .setTargetId(postId.toString())
+                    .setStatus("400"));
             throw new PostImageNotFoundException("삭제할 이미지 URL이 없습니다.");
         }
     }
@@ -103,6 +132,7 @@ public class PostImageService  {
 
 
     public List<PostImageResponse> findImagesByPostId(Long postId) {
+        log.debug("이미지 목록 조회: postId={}", postId);
         List<PostImage> postImages = postImageRepository.findByPostId(postId);
         return postImages.stream()
                 .map(PostImageResponse::from)
@@ -116,4 +146,3 @@ public class PostImageService  {
     }
 
 }
-

--- a/src/test/java/kr/co/pinup/postImages/service/PostImageServiceUnitTest.java
+++ b/src/test/java/kr/co/pinup/postImages/service/PostImageServiceUnitTest.java
@@ -1,5 +1,6 @@
 package kr.co.pinup.postImages.service;
 
+import kr.co.pinup.custom.logging.AppLogger;
 import kr.co.pinup.custom.s3.S3Service;
 import kr.co.pinup.custom.s3.exception.ImageDeleteFailedException;
 import kr.co.pinup.members.Member;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -38,6 +40,9 @@ class PostImageServiceUnitTest {
     @Mock
     private S3Service s3Service;
 
+    @Mock
+    private AppLogger appLogger;
+
     private Post mockPost;
 
     @BeforeEach
@@ -51,6 +56,7 @@ class PostImageServiceUnitTest {
                 .title("title")
                 .content("content")
                 .build();
+        ReflectionTestUtils.setField(mockPost, "id", 1L);
     }
 
     @Test


### PR DESCRIPTION
## 요약

PostImageService 및 S3Service 전반에 구조화 로깅(AppLogger)을 적용하고, 관련 유닛 테스트(PostImageServiceUnitTest)를 보완했습니다.

---

## 작업 내용

- `PostImageService`  
  - AppLogger 기반의 `InfoLog`, `WarnLog`, `ErrorLog` 적용
  - 로그에 상태 코드, 예외 메시지, 관련 ID 포함하여 구조화

- `S3Service`  
  - 업로드/삭제 로직에 AppLogger 기반 로깅 적용
  - 파일명, 예외 메시지 포함하여 명확한 추적 가능

- `S3Config`  
  - S3Client 생성 성공 시점에 로깅 추가

---

###  테스트 개선
- `PostImageServiceUnitTest`
  - `@Mock AppLogger` 추가하여 NPE 방지
  - `Post` 객체에 ID 수동 설정 (`ReflectionTestUtils`)로 `post.getId().toString()` 호출 가능하게 수정

---

## 참고 사항
- 테스트 환경에서는 JPA가 실제 DB에 flush되지 않으므로 ID는 수동 설정 필요
- 구조화 로깅은 JSON 형태로 출력되며 운영 환경에서의 로그 분석 및 추적에 용이합니다

---

## 관련 이슈

- Close #이슈번호