### PR TITLE
feat: Commets 도메인 AppLogger 구조화 로깅 도입 및 테스트 개선

### DIFF
--- a/src/main/java/kr/co/pinup/comments/controller/CommentApiController.java
+++ b/src/main/java/kr/co/pinup/comments/controller/CommentApiController.java
@@ -27,6 +27,7 @@ public class CommentApiController {
     @PreAuthorize("isAuthenticated() and (hasRole('ROLE_USER') or hasRole('ROLE_ADMIN'))")
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(@PathVariable @Positive Long commentId) {
+        log.debug("댓글 삭제 API 호출: commentId={}", commentId);
         commentService.deleteComment(commentId);
         return ResponseEntity.noContent().build();
     }
@@ -34,6 +35,7 @@ public class CommentApiController {
     @PreAuthorize("isAuthenticated() and (hasRole('ROLE_USER') or hasRole('ROLE_ADMIN'))")
     @PostMapping("/{postId}")
     public ResponseEntity<CommentResponse> createComment(@LoginMember MemberInfo memberInfo, @PathVariable @Positive Long postId, @Valid @RequestBody CreateCommentRequest createCommentRequest) {
+        log.debug("댓글 생성 API 호출: postId={}, nickname={}", postId, memberInfo.nickname());
         return new ResponseEntity<>(commentService.createComment(memberInfo, postId, createCommentRequest), HttpStatus.CREATED);
     }
 

--- a/src/test/java/kr/co/pinup/comments/service/CommentServiceUnitTest.java
+++ b/src/test/java/kr/co/pinup/comments/service/CommentServiceUnitTest.java
@@ -5,6 +5,7 @@ import kr.co.pinup.comments.exception.comment.CommentNotFoundException;
 import kr.co.pinup.comments.model.dto.CommentResponse;
 import kr.co.pinup.comments.model.dto.CreateCommentRequest;
 import kr.co.pinup.comments.repository.CommentRepository;
+import kr.co.pinup.custom.logging.AppLogger;
 import kr.co.pinup.members.Member;
 import kr.co.pinup.members.custom.WithMockMember;
 import kr.co.pinup.members.model.dto.MemberInfo;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -42,6 +44,9 @@ public class CommentServiceUnitTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private AppLogger appLogger;
 
     @Test
     @DisplayName("게시글 ID로 댓글 조회 - 성공")
@@ -129,6 +134,7 @@ public class CommentServiceUnitTest {
                 .member(mockMember)
                 .content(commentContent)
                 .build();
+        ReflectionTestUtils.setField(savedComment, "id", 1L);
 
         CommentResponse expectedResponse = CommentResponse.builder()
                 .id(savedComment.getId())


### PR DESCRIPTION
## 요약

Comment 도메인에 구조화 로깅(AppLogger)을 적용하고, 유닛 테스트에서 관련 설정을 보완했습니다.

---

## 작업 내용

- CommentApiController
  - API 진입 지점에 DEBUG 로그 추가 (Slf4j 사용)

- CommentService
  - AppLogger 기반 InfoLog, WarnLog, ErrorLog 적용
  - 예외 메시지, 식별자(postId, commentId 등) 포함한 구조화 로그 작성

---

###  테스트 개선
- CommentServiceUnitTest
  - @Mock AppLogger 추가하여 NPE 방지
  - Comment 객체에 ID 수동 설정 (ReflectionTestUtils 사용)

---

## 참고 사항
- 테스트 환경에서는 JPA가 실제 DB에 flush되지 않으므로 ID는 수동 설정 필요
- 구조화 로깅은 JSON 형태로 출력되며 운영 환경에서의 로그 분석 및 추적에 용이합니다

---

## 관련 이슈

- Close #이슈번호