### PR TITLE
feat: 좋아요 API 중복 처리 로직 개선 및 재시도 안정화 (6회 적용)

### DIFF
--- a/src/main/java/kr/co/pinup/config/RetryConfig.java
+++ b/src/main/java/kr/co/pinup/config/RetryConfig.java
@@ -21,7 +21,7 @@ public class RetryConfig {
         RetryTemplate retryTemplate = new RetryTemplate();
 
         SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(
-                5,
+                6,
                 Map.of(
                         ObjectOptimisticLockingFailureException.class, true,
                         JpaOptimisticLockingFailureException.class, true,

--- a/src/main/java/kr/co/pinup/postLikes/controller/PostLikeApiController.java
+++ b/src/main/java/kr/co/pinup/postLikes/controller/PostLikeApiController.java
@@ -1,12 +1,12 @@
 package kr.co.pinup.postLikes.controller;
 
+import kr.co.pinup.custom.loginMember.LoginMember;
 import kr.co.pinup.members.model.dto.MemberInfo;
-import kr.co.pinup.postLikes.service.PostLikeService;
 import kr.co.pinup.postLikes.model.dto.PostLikeResponse;
+import kr.co.pinup.postLikes.service.PostLikeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,7 +23,7 @@ public class PostLikeApiController {
     @PostMapping("/{postId}")
     @ResponseBody
     public PostLikeResponse toggleLike(@PathVariable Long postId,
-                                       @AuthenticationPrincipal MemberInfo memberInfo) {
+                                       @LoginMember MemberInfo memberInfo) {
         log.debug("게시글 좋아요API 호출: postId={}, nickname={}", postId, memberInfo.nickname());
         return postLikeService.toggleLike(postId, memberInfo);
     }


### PR DESCRIPTION
## 요약

좋아요 API의 중복 요청 처리 및 동시성 대응 강화를 위해 기존 예외 기반 로직을 **명시적 조건 분기 방식**으로 개선하였습니다.

낙관적 락 기반 재시도 로직(`RetryTemplate`)은 유지하되, 트랜잭션 흐름을 단순화하고 테스트 신뢰성을 확보하였습니다.

---

## 작업 내용

### 기능 개선

- `PostLikeService`에서 `existsByPostIdAndMemberId()` 사전 조회 방식으로 중복 여부 판단
- 예외 기반 분기(DataIntegrityViolationException) 제거 → 명확한 if-else 조건 분기로 전환
- 좋아요 등록/취소 모두에 `PostRepository.findByIdWithOptimisticLock()` 사용해 낙관적 락 적용
- `AtomicReference` 제거 (상태 공유 불필요)
- `Post` 도메인에 `increaseLikeCount()`, `decreaseLikeCount()` 명확히 분리된 로직 호출
- 재시도 정책은 유지하되, 최대 재시도 횟수를 **5 → 6회로 증가**하여 안정성 향상

---

### 테스트 코드 보완

- `PostLikeServiceUnitTest` 단위 테스트 정비
    - `Post` 객체는 `Mockito.mock(Post.class, withSettings().lenient())`로 설정
    - `increaseLikeCount()`, `decreaseLikeCount()` 호출 여부 `verify()`로 명확히 검증
- 흐름 테스트 커버리지
    - 좋아요 등록 → 저장 확인
    - 좋아요 취소 → 삭제 및 카운트 감소 확인
    - 존재하지 않는 회원 / 게시글에 대한 예외 처리 검증

---

### 성능 및 부하 테스트 기반 개선

- `RetryTemplate` 설정 유지:
    - 최대 재시도: **6회**
    - 지연 전략: `ExponentialRandomBackOffPolicy`
        - 초기 지연: 200ms
        - multiplier: 1.8
        - 최대 지연: 2500ms

---

### 📊 k6 좋아요 동시성 200명 테스트 결과 요약

| 실험 | 재시도 횟수 | 초기 지연 | 배수 | 최대 지연 | 전략 요약 | 실패율 | 평균 응답 시간 | 90% 응답 시간 | 비고 |
|------|--------------|------------|------|-------------|----------------|---------|------------------|----------------|-----------------------------|
| A    | 5회          | 200ms      | 1.8  | 2500ms      | 초기 전략      | 8.5%    | 4.71s            | 9.82s          | 응답 지연, 실패 많음        |
| B    | 5회          | 200ms      | 1.8  | 2500ms      | 개선 시도 1차  | 1.25%   | 1.02s            | 2.69s          | 큰 개선 효과                |
| C    | 6회          | 200ms      | 1.8  | 2500ms      | 재시도 증가    | 1.5%    | 4.68s            | 9.57s          | 안정성 ↑, 속도는 보통       |
| D    | 6회          | 200ms      | 1.8  | 2500ms      | 안정화 결과    | 1.0%    | 1.38s            | 3.98s          | 최종 안정화 확인            |

### 테스트 진행 배경 및 설명

- 테스트는 동일한 설정이라도 **Spring Boot 초기 부팅 직후 첫 요청은 상대적으로 느릴 수 있다**는 점을 고려해,  
  **각 전략별로 게시글 ID를 달리해 두 차례씩 실험**을 진행했습니다.
- A, C는 각각 전략 적용 후 **첫 번째 실행 (게시글 ID 3)** 으로 부팅 직후 테스트에 해당합니다.
- B, D는 **동일 설정을 유지한 상태에서 두 번째 게시글 (ID 4)** 로 테스트해 보다 **안정적인 수치**를 확인했습니다.

> 따라서 최종적으로는 D 실험이 가장 안정적인 응답 속도와 성공률을 보였으며,  
> **재시도 횟수 6회, backoff 기본 설정 유지 전략을 채택**하여 안정화 완료하였습니다.

---

## 참고 사항
- RetryTemplate 기반 재시도 로직은 기존 PR에서 도입된 구조를 유지했습니다.
- 문서화 및 부하 테스트 스크립트는 이전 PR과 동일하게 별도 관리됩니다.
---

## 관련 이슈

Close #이슈번호 ← 실제 이슈 번호에 맞게 수정
