### PR TITLE
feat: 운영시 .js를 .min.js로 치환하도록 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.1'
@@ -7,7 +10,7 @@ plugins {
 }
 
 group = 'kr.co'
-version = '1.1.0'
+version = '1.1.1'
 
 java {
 	toolchain {
@@ -157,6 +160,27 @@ fileTree('src/main/resources/static/js').each { file ->
 	}
 }
 
+def replaceImportPaths = tasks.register("replaceImportPaths") {
+	onlyIf { project.hasProperty('prod') }
+	dependsOn minifyTasks
+
+	doLast {
+		def jsDir = layout.buildDirectory.dir("resources/main/static/js").get().asFile
+		fileTree(jsDir).include("**/*.min.js").each { file ->
+			def content = file.text
+
+			// from 뒤에 오는 "경로.js" 부분을 찾아 "경로.min.js"로 변경
+			def newContent = content.replaceAll(/(from\s*["'])([^"']*?)(\.js)(["'])/, '$1$2.min.js$4')
+
+			// 변경이 일어난 경우에만 파일을 다시 씀
+			if (content != newContent) {
+				println "Replacing import paths in: ${file.name}" // 변경 로그 출력
+				Files.write(file.toPath(), newContent.getBytes(StandardCharsets.UTF_8))
+			}
+		}
+	}
+}
+
 processResources {
 	if (project.hasProperty('prod')) {
 		exclude 'static/js/*.js'
@@ -175,7 +199,7 @@ tasks.named('asciidoctor') {
 
 bootJar {
 	enabled = true
-	dependsOn minifyTasks
+	dependsOn replaceImportPaths
 	dependsOn asciidoctor              // 문서 생성 후 jar 생성
 	from("${asciidoctor.outputDir}") {
 		into 'static/docs'             // 문서 접근 경로 (http://localhost:8080/docs/)


### PR DESCRIPTION
## 요약
- 운영시 압축&난독화로 *.min.js 파일을 사용하기위해 .js를 .min.js로 치환
- 에러 수정으로 버전 `1.1.0` -> `1.1.1`로 업데이트

## 작업 내용
- prod build 시 .js가 있는 코드들을 .min.js로 치환
- 에러 수정으로 버전 `1.1.0` -> `1.1.1`로 업데이트

## 참고 사항

## 관련 이슈

- Close #이슈번호