### PR TITLE
feat: 팝업스토어 리스트 조회시 진행상태와 자치구 필터 기능으로 조회할 수 있도록 추가

### DIFF
--- a/src/main/java/kr/co/pinup/stores/controller/StoreController.java
+++ b/src/main/java/kr/co/pinup/stores/controller/StoreController.java
@@ -29,16 +29,14 @@ public class StoreController {
     private final StoreCategoryService storeCategoryService;
 
     @GetMapping
-    public String listStores(@RequestParam(required = false) String status, Model model) {
-        if (status == null) {
-            return "redirect:/stores?status=resolved";
-        }
+    public String listStores(
+            @RequestParam String status,
+            @RequestParam String sigungu,
+            Model model) {
+        log.info("StoreController listStores status={}, sigungu={}", status, sigungu);
 
-        log.info("StoreController listStores status={}", status);
         StoreStatus selectedStatus = StoreStatus.from(status);
-        final List<StoreThumbnailResponse> stores = (selectedStatus != null)
-                ? storeService.getStoresByStatus(selectedStatus)
-                : storeService.getStoresSortedByStatusPriority();
+        List<StoreThumbnailResponse> stores = storeService.findAll(selectedStatus, sigungu);
 
         model.addAttribute("selectedStatus", selectedStatus);
         model.addAttribute("stores", stores);

--- a/src/main/java/kr/co/pinup/stores/repository/StoreRepository.java
+++ b/src/main/java/kr/co/pinup/stores/repository/StoreRepository.java
@@ -1,6 +1,7 @@
 package kr.co.pinup.stores.repository;
 
 import kr.co.pinup.stores.Store;
+import kr.co.pinup.stores.model.dto.StoreThumbnailResponse;
 import kr.co.pinup.stores.model.enums.StoreStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,7 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
     List<Store> findAllByStoreStatusAndIsDeletedFalse(StoreStatus status);
 
+    List<Store> findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(String sigungu, StoreStatus selectedStatus);
+
+    List<Store> findAllByLocation_SigunguAndIsDeletedFalse(String sigungu);
 }

--- a/src/main/resources/static/css/store_list.css
+++ b/src/main/resources/static/css/store_list.css
@@ -119,3 +119,24 @@
     outline: none;
     border-color: #a89c8f;
 }
+
+#sigungu-filter {
+    background-color: #f9f5ef;
+    color: #3c2f2f;
+    border: 1px solid #cbbfb0;
+    border-radius: 6px;
+    padding: 6px 30px 6px 12px;
+    font-size: 14px;
+    appearance: none;
+    background-image: url("data:image/svg+xml;utf8,<svg fill='%233c2f2f' height='16' viewBox='0 0 24 24' width='16' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    background-size: 16px;
+    cursor: pointer;
+    transition: border-color 0.2s ease-in-out;
+}
+
+#sigungu-filter:focus {
+    outline: none;
+    border-color: #a89c8f;
+}

--- a/src/main/resources/static/js/store-list.js
+++ b/src/main/resources/static/js/store-list.js
@@ -1,7 +1,22 @@
 document.addEventListener("DOMContentLoaded", function () {
     const statusFilter = document.getElementById("statusFilter");
+    const sigunguFilter = document.getElementById('sigungu-filter');
+
+    const urlParams = new URLSearchParams(window.location.search);
+    if (statusFilter && urlParams.has('status')) {
+        statusFilter.value = urlParams.get('status');
+    }
+    if (sigunguFilter && urlParams.has('sigungu')) {
+        sigunguFilter.value = urlParams.get('sigungu');
+    }
+
     if (statusFilter) {
         statusFilter.addEventListener("change", function () {
+            this.form.submit();
+        });
+    }
+    if (sigunguFilter) {
+        sigunguFilter.addEventListener('change', function () {
             this.form.submit();
         });
     }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -11,7 +11,7 @@
     <nav>
         <ul>
             <li><a th:href="@{/}">홈</a></li>
-            <li><a th:href="@{/stores}">팝업스토어</a></li>
+            <li><a th:href="@{/stores?status=resolved&sigungu=all}">팝업스토어</a></li>
             <li><a th:href="@{/notices}">고객센터</a></li>
         </ul>
     </nav>

--- a/src/main/resources/templates/views/stores/list.html
+++ b/src/main/resources/templates/views/stores/list.html
@@ -13,17 +13,49 @@
         <a th:href="@{/stores/create}" class="create-btn">등록</a>
     </div>
 
-    <form method="get" action="/stores">
-        <label for="statusFilter">진행 상태 : </label>
-        <select name="status" id="statusFilter" onchange="this.form.submit()">
-            <option th:value="all" th:selected="${selectedStatus == null}">전체</option>
-            <option th:each="statusOption : ${T(kr.co.pinup.stores.model.enums.StoreStatus).values()}"
-                    th:value="${statusOption.name().toLowerCase()}"
-                    th:text="${statusOption.value}"
-                    th:selected="${selectedStatus?.name() == statusOption.name()}">
-            </option>
-        </select>
-    </form>
+    <div>
+        <form method="get" action="/stores">
+            <label for="statusFilter">진행 상태 : </label>
+            <select name="status" id="statusFilter" onchange="this.form.submit()">
+                <option th:value="all" th:selected="${selectedStatus == null}">전체</option>
+                <option th:each="statusOption : ${T(kr.co.pinup.stores.model.enums.StoreStatus).values()}"
+                        th:value="${statusOption.name().toLowerCase()}"
+                        th:text="${statusOption.value}"
+                        th:selected="${selectedStatus?.name() == statusOption.name()}">
+                </option>
+            </select>
+
+            <label for="sigungu-filter">자치구 : </label>
+            <select name="sigungu" id="sigungu-filter" onchange="this.form.submit()">
+                <option value="all" th:selected="${selectedSigungu == null}">전체</option>
+                <option value="강남구" th:selected="${selectedSigungu == '강남구'}">강남구</option>
+                <option value="강동구" th:selected="${selectedSigungu == '강동구'}">강동구</option>
+                <option value="강북구" th:selected="${selectedSigungu == '강북구'}">강북구</option>
+                <option value="강서구" th:selected="${selectedSigungu == '강서구'}">강서구</option>
+                <option value="관악구" th:selected="${selectedSigungu == '관악구'}">관악구</option>
+                <option value="광진구" th:selected="${selectedSigungu == '광진구'}">광진구</option>
+                <option value="구로구" th:selected="${selectedSigungu == '구로구'}">구로구</option>
+                <option value="금천구" th:selected="${selectedSigungu == '금천구'}">금천구</option>
+                <option value="노원구" th:selected="${selectedSigungu == '노원구'}">노원구</option>
+                <option value="도봉구" th:selected="${selectedSigungu == '도봉구'}">도봉구</option>
+                <option value="동대문구" th:selected="${selectedSigungu == '동대문구'}">동대문구</option>
+                <option value="동작구" th:selected="${selectedSigungu == '동작구'}">동작구</option>
+                <option value="마포구" th:selected="${selectedSigungu == '마포구'}">마포구</option>
+                <option value="서대문구" th:selected="${selectedSigungu == '서대문구'}">서대문구</option>
+                <option value="서초구" th:selected="${selectedSigungu == '서초구'}">서초구</option>
+                <option value="성동구" th:selected="${selectedSigungu == '성동구'}">성동구</option>
+                <option value="성북구" th:selected="${selectedSigungu == '성북구'}">성북구</option>
+                <option value="송파구" th:selected="${selectedSigungu == '송파구'}">송파구</option>
+                <option value="양천구" th:selected="${selectedSigungu == '양천구'}">양천구</option>
+                <option value="영등포구" th:selected="${selectedSigungu == '영등포구'}">영등포구</option>
+                <option value="용산구" th:selected="${selectedSigungu == '용산구'}">용산구</option>
+                <option value="은평구" th:selected="${selectedSigungu == '은평구'}">은평구</option>
+                <option value="종로구" th:selected="${selectedSigungu == '종로구'}">종로구</option>
+                <option value="중구" th:selected="${selectedSigungu == '중구'}">중구</option>
+                <option value="중랑구" th:selected="${selectedSigungu == '중랑구'}">중랑구</option>
+            </select>
+        </form>
+    </div>
 
     <div class="store-list">
         <div th:each="store : ${stores}" class="store-card">

--- a/src/test/java/kr/co/pinup/stores/controller/StoreControllerTest.java
+++ b/src/test/java/kr/co/pinup/stores/controller/StoreControllerTest.java
@@ -58,13 +58,15 @@ public class StoreControllerTest {
     void listStores() throws Exception {
         // Arrange
         final StoreStatus status = RESOLVED;
+        final String sigungu = "all";
         final List<StoreThumbnailResponse> stores = List.of();
 
         given(storeService.getStoresByStatus(status)).willReturn(stores);
 
         // Act & Assert
         mockMvc.perform(get("/stores")
-                        .param("status", "resolved"))
+                        .param("status", "resolved")
+                        .param("sigungu", sigungu))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(view().name(VIEW_PATH + "/list"))
@@ -72,19 +74,7 @@ public class StoreControllerTest {
                 .andExpect(model().attributeExists("stores"));
 
         then(storeService).should(times(1))
-                .getStoresByStatus(status);
-    }
-
-    @DisplayName("status가 없을 때 RESOLVED로 리다이렉트된다ㅣ")
-    @Test
-    void listStoresRedirectWhenNoStatus() throws Exception {
-        // Arrange
-
-        // Act & Assert
-        mockMvc.perform(get("/stores"))
-                .andDo(print())
-                .andExpect(status().is3xxRedirection())
-                .andExpect(redirectedUrl("/stores?status=resolved"));
+                .findAll(status, sigungu);
     }
 
     @DisplayName("팝업스토어 detail 페이지 뷰를 반환한다")

--- a/src/test/java/kr/co/pinup/stores/service/StoreServiceTest.java
+++ b/src/test/java/kr/co/pinup/stores/service/StoreServiceTest.java
@@ -87,6 +87,124 @@ public class StoreServiceTest {
                 .findAllByIsDeletedFalse();
     }
 
+    @DisplayName("진행상태, 자치구 필터로 팝업스토어 리스트 전체 조회")
+    @Test
+    void findAllWithStoreStatusNotAllAndSigunguNotAll() {
+        // Arrange
+        final StoreStatus storeStatus = RESOLVED;
+        final String sigungu = "송파구";
+
+        final Store store1 = createStore("Store 1", "Store description 1", RESOLVED);
+        final Store store2 = createStore("Store 2", "Store description 2", PENDING);
+        final Store store3 = createStore("Store 3", "Store description 3", RESOLVED);
+
+        given(storeRepository.findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus))
+                .willReturn(List.of(store1, store3));
+
+        // Act
+        final List<StoreThumbnailResponse> result = storeService.findAll(storeStatus, sigungu);
+
+        // Assert
+        assertThat(result).hasSize(2);
+
+        then(storeRepository).should(times(1))
+                .findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus);
+        then(storeRepository).should(times(0))
+                .findAllByStoreStatusAndIsDeletedFalse(storeStatus);
+        then(storeRepository).should(times(0))
+                .findAllByLocation_SigunguAndIsDeletedFalse(sigungu);
+        then(storeRepository).should(times(0))
+                .findAllByIsDeletedFalse();
+    }
+
+    @DisplayName("진행상태 필터로 팝업스토어 리스트 전체 조회")
+    @Test
+    void findAllWithStoreStatusNotAllAndSigunguAll() {
+        // Arrange
+        final StoreStatus storeStatus = RESOLVED;
+        final String sigungu = "all";
+
+        final Store store1 = createStore("Store 1", "Store description 1", RESOLVED);
+        final Store store2 = createStore("Store 2", "Store description 2", PENDING);
+        final Store store3 = createStore("Store 3", "Store description 3", RESOLVED);
+
+        given(storeRepository.findAllByStoreStatusAndIsDeletedFalse(storeStatus)).willReturn(List.of(store1, store3));
+
+        // Act
+        final List<StoreThumbnailResponse> result = storeService.findAll(storeStatus, sigungu);
+
+        // Assert
+        assertThat(result).hasSize(2);
+
+        then(storeRepository).should(times(0))
+                .findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus);
+        then(storeRepository).should(times(1))
+                .findAllByStoreStatusAndIsDeletedFalse(storeStatus);
+        then(storeRepository).should(times(0))
+                .findAllByLocation_SigunguAndIsDeletedFalse(sigungu);
+        then(storeRepository).should(times(0))
+                .findAllByIsDeletedFalse();
+    }
+
+    @DisplayName("자치구 필터로 팝업스토어 리스트 전체 조회")
+    @Test
+    void findAllWithStoreStatusAllAndSigunguNotAll() {
+        // Arrange
+        final StoreStatus storeStatus = null;
+        final String sigungu = "송파구";
+
+        final Store store1 = createStore("Store 1", "Store description 1", RESOLVED);
+        final Store store2 = createStore("Store 2", "Store description 2", PENDING);
+        final Store store3 = createStore("Store 3", "Store description 3", RESOLVED);
+
+        given(storeRepository.findAllByLocation_SigunguAndIsDeletedFalse(sigungu))
+                .willReturn(List.of(store1, store2, store3));
+
+        // Act
+        final List<StoreThumbnailResponse> result = storeService.findAll(storeStatus, sigungu);
+
+        // Assert
+        assertThat(result).hasSize(3);
+
+        then(storeRepository).should(times(0))
+                .findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus);
+        then(storeRepository).should(times(0))
+                .findAllByStoreStatusAndIsDeletedFalse(storeStatus);
+        then(storeRepository).should(times(1))
+                .findAllByLocation_SigunguAndIsDeletedFalse(sigungu);
+        then(storeRepository).should(times(0))
+                .findAllByIsDeletedFalse();
+    }
+
+    @DisplayName("필터 없이 팝업스토어 리스트 전체 조회")
+    @Test
+    void findAllWithStoreStatusAllAndSigunguAll() {
+        // Arrange
+        final StoreStatus storeStatus = null;
+        final String sigungu = "all";
+
+        final Store store1 = createStore("Store 1", "Store description 1", RESOLVED);
+        final Store store2 = createStore("Store 2", "Store description 2", PENDING);
+        final Store store3 = createStore("Store 3", "Store description 3", RESOLVED);
+
+        given(storeRepository.findAllByIsDeletedFalse()).willReturn(List.of(store1, store2, store3));
+
+        // Act
+        final List<StoreThumbnailResponse> result = storeService.findAll(storeStatus, sigungu);
+
+        // Assert
+        assertThat(result).hasSize(3);
+
+        then(storeRepository).should(times(0))
+                .findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus);
+        then(storeRepository).should(times(0))
+                .findAllByStoreStatusAndIsDeletedFalse(storeStatus);
+        then(storeRepository).should(times(0))
+                .findAllByLocation_SigunguAndIsDeletedFalse(sigungu);
+        then(storeRepository).should(times(1))
+                .findAllByIsDeletedFalse();
+    }
+
     @DisplayName("팝업스토어 상태를 정렬해서 limit 수만큼 조회한다")
     @Test
     void getStoresThumbnailWithLimit() {
@@ -214,6 +332,53 @@ public class StoreServiceTest {
 
         then(storeRepository).should(times(1))
                 .findById(storeId);
+    }
+
+    @DisplayName("진행상태, 자치구 필터로 팝업스토어를 조회한다")
+    @Test
+    void getStoresByStatusAndLocationBySigungu() {
+        // Arrange
+        final StoreStatus storeStatus = PENDING;
+        final String sigungu = "송파구";
+
+        final Store store1 = createStore("Store 1", "Store description 1", RESOLVED);
+        final Store store2 = createStore("Store 2", "Store description 2", PENDING);
+        final Store store3 = createStore("Store 3", "Store description 3", RESOLVED);
+
+        given(storeRepository.findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus))
+                .willReturn(List.of(store2));
+
+        // Act
+        final List<StoreThumbnailResponse> result = storeService.getStoresByStatusAndLocationBySigungu(storeStatus, sigungu);
+
+        // Assert
+        assertThat(result).hasSize(1);
+
+        then(storeRepository).should(times(1))
+                .findAllByLocation_SigunguAndStoreStatusAndIsDeletedFalse(sigungu, storeStatus);
+    }
+
+    @DisplayName("자치구 필터로 팝업스토어를 조회한다")
+    @Test
+    void getStoresByLocationBySigungu() {
+        // Arrange
+        final String sigungu = "송파구";
+
+        final Store store1 = createStore("Store 1", "Store description 1", RESOLVED);
+        final Store store2 = createStore("Store 2", "Store description 2", PENDING);
+        final Store store3 = createStore("Store 3", "Store description 3", RESOLVED);
+
+        given(storeRepository.findAllByLocation_SigunguAndIsDeletedFalse(sigungu))
+                .willReturn(List.of(store1, store2, store3));
+
+        // Act
+        final List<StoreThumbnailResponse> result = storeService.getStoresByLocationBySigungu(sigungu);
+
+        // Assert
+        assertThat(result).hasSize(3);
+
+        then(storeRepository).should(times(1))
+                .findAllByLocation_SigunguAndIsDeletedFalse(sigungu);
     }
 
     @DisplayName("팝업스토어 정보를 저장한다")


### PR DESCRIPTION
## 요약
- 팝업스토어 리스트 조회할 때 진행상태&자치구 필터로 조회 가능하도록 기능 추가

## 작업 내용
### FrontEnd
- 리스트 뷰에서 select 태그에 자치구 리스트 하드코딩으로 추가
- 헤더의 팝업리스트 버튼 클릭시 url parameter에 `?status=resolved&sigungu=all`로 설정

### BackEnd
#### Store Controller
- status 초기값 지정으로 controller에서 status null일 경우 redirect 하는 로직 제거

#### Store Service
- 필터 케이스별로 조회하도록 메소드 추가
  - status가 all이 아닌 경우 & sigungu가 all이 아닌 경우
  - status가 all이 아닌 경우 & sigungu가 all인 경우
  - status가 all인 경우 & sigungu가 all이 아닌 경우
  - status가 all인 경우 & sigungu가 all인 경우
- 팝업 등록할 때 팝업 종료 날짜가 현재 날짜보다 이전이면 종료 상태로 지정하지 않는 예외 케이스가 있어서 수정
  - 일반적으로 등록할 때 종료된 팝업은 등록하지 않지만, 예외 케이스로 로직은 구현할 필요가 있어서 구현

#### Store Repository
- repository에 status&sigungu를 조건으로 조회하는 메소드 추가
- repository에 sigungu를 조건으로 조회하는 메소드 추가

#### Test
- 추가된 service 메소드 단위 테스트 추가

## 참고 사항

## 관련 이슈

- Close #이슈번호