### PR TITLE
chore(github): Org Project #2 자동화 도입 — 이슈 폼 & 워크플로 추가 + .gitignore 예외

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,138 @@
+name: Work Item (Tables)
+description: 테이블(도메인) 단위 운영 작업 생성
+title: "[Task] issue "
+labels: []
+
+body:
+  # --- 상단 안내/도움말(가독성 향상) ---
+  - type: markdown
+    attributes:
+      value: |
+        ### 🧾 Quick summary
+        이 폼은 카드에 **Priority / Component / Change Type / Due Date** 4가지만 칩으로 보이도록 설계되어 있습니다.  
+        아래 **도움말**을 참고해 각 항목을 빠르게 선택하세요.
+
+        <details>
+        <summary><strong>도움말 펼치기</strong> (Change Type / Component / Priority / Due Date 안내)</summary>
+
+        #### 🏷 Change Type (작업 성격)
+        - `feat` : 신규 기능 추가  
+        - `fix` : 버그 수정  
+        - `refactor` : 내부 구조 개선(동작 동일)  
+        - `docs` : 문서만 수정  
+        - `chore` : 유지보수/도구/종속성 등(로직 영향 없음)  
+        - `perf` : 성능 개선(더 빠름/적은 리소스)  
+        - `test` : 테스트 추가/수정  
+        - `ci` : CI 파이프라인 변경  
+        - `build` : 빌드/패키징/종속성 변경  
+        - `revert` : 변경 되돌리기
+
+        #### 🧩 Component (대표 도메인 선택)
+        - `members`(회원/계정), `posts`(게시글/피드), `comments`(댓글), `post_like`(좋아요), `post_images`(게시글 이미지)  
+        - `notices`(공지), `faqs`(FAQ)  
+        - `stores`(매장), `store_categories`(매장 카테고리), `store_images`(매장 이미지), `store_operating_hour`(영업시간), `locations`(위치/지점)  
+        - `verification`(계정/매장 인증)
+
+        #### 🚨 Priority (영향/긴급도)
+        - **Critical**: 서비스 중단·보안·데이터 손실 등 즉시 대응  
+        - **High**: 핵심 기능 영향, 다수 사용자 영향 → 스프린트 우선 처리  
+        - **Medium**: 일반 개선/경미한 버그  
+        - **Low**: 낮은 영향의 정리 작업
+
+        #### 📅 Due Date (마감일)
+        - 형식: `YYYY-MM-DD` (예: `2025-09-12`)  
+        - **비워두면** 워크플로가 KST ‘오늘’로 자동 설정합니다.  
+        - 칸반 카드에는 날짜 칩(예: `Nov 6, 2025`)으로 표시됩니다.  
+        - 카드/사이드패널에서 직접 수정해도 워크플로가 **덮어쓰지 않습니다.**
+
+        </details>
+
+  # 핵심 메타 4종 —— (워크플로가 동기화)
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: 작업의 비즈니스 임팩트/긴급도
+      options: [Critical, High, Medium, Low]
+    validations:
+
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: 작업 테이블(대표 도메인) 1개를 선택하세요
+      options:
+        - comments
+        - faqs
+        - locations
+        - members
+        - notices
+        - post_images
+        - post_like
+        - posts
+        - store_categories
+        - store_images
+        - store_operating_hour
+        - stores
+        - verification
+
+#  - type: checkboxes
+#    id: affected_tables
+#    attributes:
+#      label: Affected Tables
+#      description: 함께 영향을 받는 테이블(복수 선택)
+#      options:
+#        - label: comments
+#        - label: faqs
+#        - label: locations
+#        - label: members
+#        - label: notices
+#        - label: post_images
+#        - label: post_like
+#        - label: posts
+#        - label: store_categories
+#        - label: store_images
+#        - label: store_operating_hour
+#        - label: stores
+#        - label: verification
+
+  - type: dropdown
+    id: change_type
+    attributes:
+      label: Change Type
+      description: 작업 성격
+      options: ["feat","fix","refactor","docs","chore","perf","test","ci","build","revert"]
+    #docs : 문서만 수정/chore : 유지보수/잡무(코드 로직 변화 없음)/perf : 성능 개선/test : 테스트 추가/수정/ci, build : 파이프라인/빌드 변경/revert : 변경 되돌리기
+    validations:
+
+
+  - type: input
+    id: due_date
+    attributes:
+      label: Due Date
+      description: YYYY-MM-DD 형식으로 입력
+      placeholder: "2025-09-12"
+    validations:
+
+
+  # 구분선
+  - type: markdown
+    attributes:
+      value: "---"
+
+  # 본문 — 카드에는 안 보이고 이슈 상세에서만 읽힘
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: 무엇/왜/어떻게 (재현 스텝, 로그/쿼리, 기대동작, 영향 범위 등)
+      placeholder: |
+        - 배경:
+        - 기대 동작:
+        - 변경 내용:
+        - 영향 범위/리스크:
+        - 테스트/검증:
+        - 롤백/모니터링:
+    validations:
+      required: true

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,21 @@
+name: Add issues/PRs to Project
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: read  # 코드 체크아웃 안 하므로 최소 권한
+
+jobs:
+  add:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          # ↓ 본인 프로젝트 URL로 교체
+          project-url: https://github.com/orgs/pinup-team/projects/2
+          # ↑ Org 프로젝트면: https://github.com/orgs/<ORG>/projects/<NUMBER>
+          github-token: ${{ secrets.PROJECTS_TOKEN }}

--- a/.github/workflows/project-fields-from-form.yml
+++ b/.github/workflows/project-fields-from-form.yml
@@ -1,0 +1,311 @@
+name: Sync issue form to Project fields (ORG)
+
+on:
+  issues:
+    types: [opened, edited]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Manual sync target issue number"
+        required: true
+        type: number
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write   # 코멘트/본문 업데이트
+
+    env:
+      # === 조직 프로젝트 설정 ===
+      ORG: "pinup-team"            # ← 조직 로그인 (organization login)
+      PROJECT_NUMBER: "2"          # ← 조직 Project(v2) 번호
+
+      # === Projects 필드명 (철자 완전 일치) ===
+      PRIORITY_FIELD_NAME: "Priority"        # Single-select
+      COMPONENT_FIELD_NAME: "Component"      # Single-select
+      CHANGE_TYPE_FIELD_NAME: "Change Type"  # Single-select
+      DUEDATE_FIELD_NAME: "Due Date"         # Date
+      SUMMARY_FIELD_NAME: "Summary"          # Text (선택)
+      DDAY_FIELD_NAME: "D-Day"               # Text (선택)
+
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECTS_TOKEN }}  # classic PAT (repo, project, read:org)
+          script: |
+            const gql = github.graphql;
+            const ops = [];
+
+            // ---------- helpers ----------
+            const KST_TODAY = () => new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Seoul' }).slice(0,10);
+            const isISO = (s) => /^\d{4}-\d{2}-\d{2}$/.test(s) && !Number.isNaN(new Date(`${s}T00:00:00Z`).getTime());
+            const stripMd = (s) => (s || "").replace(/(^_+|_+$)/g,"").replace(/[ *`~>|]/g,"").trim();
+            const emptyLike = (s) => !s || /^no response$/i.test(s) || /^n\/a$/i.test(s) || /^none$/i.test(s) || /^-+$/.test(s);
+            const ddayLabel = (n) => n===0 ? "D-Day" : n>0 ? `D-${n}` : `D+${Math.abs(n)}`;
+            const diffDaysKST = (iso) => {
+              if (!iso) return null;
+              const tz = "Asia/Seoul";
+              const todayStr = new Date().toLocaleString("sv-SE", { timeZone: tz }).slice(0,10);
+              const [ty,tm,td] = todayStr.split("-").map(Number);
+              const [y,m,d]    = iso.split("-").map(Number);
+              const t0 = Date.UTC(ty, tm-1, td);
+              const d0 = Date.UTC(y, m-1, d);
+              return Math.round((d0 - t0) / 86400000);
+            };
+
+            // ---------- 0) 프로젝트 메타 (ORG 기반) ----------
+            const orgLogin = (process.env.ORG || "").trim();
+            const projectNumber = Number(process.env.PROJECT_NUMBER || "0");
+            if (!orgLogin || !projectNumber) { core.setFailed("ORG/PROJECT_NUMBER missing"); return; }
+
+            const resOrg = await gql(`
+              query($login:String!, $num:Int!) {
+                organization(login:$login){
+                  projectV2(number:$num){
+                    id title
+                    fields(first:100){
+                      nodes{
+                        ... on ProjectV2FieldCommon       { id name }
+                        ... on ProjectV2SingleSelectField { id name options { id name } }
+                        ... on ProjectV2Field             { id name }
+                      }
+                    }
+                  }
+                }
+              }
+            `, { login: orgLogin, num: projectNumber });
+
+            const project = resOrg?.organization?.projectV2;
+            if (!project) { core.setFailed("Project not found. Check ORG/PROJECT_NUMBER."); return; }
+            const fields = project.fields.nodes || [];
+            const byName = (n) => fields.find(f => f && f.name === n);
+
+            const fPriority   = byName(process.env.PRIORITY_FIELD_NAME);
+            const fComponent  = byName(process.env.COMPONENT_FIELD_NAME);
+            const fChangeType = byName(process.env.CHANGE_TYPE_FIELD_NAME);
+            const fDue        = byName(process.env.DUEDATE_FIELD_NAME);
+            const fSummary    = byName(process.env.SUMMARY_FIELD_NAME);
+            const fDDay       = byName(process.env.DDAY_FIELD_NAME);
+
+            // ---------- 1) 대상 이슈 ----------
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            let issue;
+            if (context.eventName === "workflow_dispatch") {
+              const num = Number(core.getInput("issue_number"));
+              if (!num) { core.setFailed("workflow_dispatch requires issue_number"); return; }
+              const { data } = await github.rest.issues.get({ owner, repo, issue_number: num });
+              issue = data;
+            } else {
+              issue = context.payload.issue;
+            }
+
+            // ---------- 2) 이슈 → 프로젝트 아이템 ----------
+            const resIssue = await gql(`
+              query($id:ID!){
+                node(id:$id){
+                  ... on Issue {
+                    id number
+                    projectItems(first:30){ nodes { id project { id } } }
+                  }
+                }
+              }`, { id: issue.node_id });
+
+            const issueNode = resIssue.node;
+            let itemId = issueNode.projectItems.nodes.find(n => n.project.id === project.id)?.id;
+            if (!itemId) {
+              const add = await gql(`
+                mutation($pid:ID!,$content:ID!){
+                  addProjectV2ItemById(input:{projectId:$pid, contentId:$content}) {
+                    item { id }
+                  }
+                }`, { pid: project.id, content: issueNode.id });
+              itemId = add.addProjectV2ItemById.item.id;
+              ops.push(`➕ Added to project "${project.title}" (Issue #${issueNode.number})`);
+            }
+
+            // ---------- 3) 현재 프로젝트 값 읽기 (fallback용) ----------
+            let currentDue = "";
+            let currentPriority = "", currentComponent = "", currentChangeType = "";
+            if (fDue || fPriority || fComponent || fChangeType) {
+              const resVals = await gql(`
+                query($item: ID!) {
+                  node(id: $item) {
+                    ... on ProjectV2Item {
+                      fieldValues(first: 50) {
+                        nodes {
+                          ... on ProjectV2ItemFieldDateValue {
+                            date
+                            field { ... on ProjectV2FieldCommon { id name } }
+                          }
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2FieldCommon { id name } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { item: itemId });
+
+              const fvs = resVals?.node?.fieldValues?.nodes || [];
+              const getByField = (fid, pick) => {
+                const n = fvs.find(n => n?.field?.id === fid);
+                return n ? pick(n) : "";
+              };
+              if (fDue)        currentDue        = getByField(fDue.id,        n => n.date || "");
+              if (fPriority)   currentPriority   = getByField(fPriority.id,   n => n.name || "");
+              if (fComponent)  currentComponent  = getByField(fComponent.id,  n => n.name || "");
+              if (fChangeType) currentChangeType = getByField(fChangeType.id, n => n.name || "");
+            }
+
+            // ---------- 4) 폼 값 파싱 + fallback ----------
+            const issueBody = issue.body || "";
+            const pick = (label) => {
+              const re = new RegExp(`^###\\s*${label}\\s*\\n+([\\s\\S]*?)(?=\\n###|$)`, "m");
+              const m = issueBody.match(re);
+              return m ? m[1].trim() : "";
+            };
+
+            let vPriority   = stripMd(pick("Priority"));
+            let vComponent  = stripMd(pick("Component"));
+            let vChangeType = stripMd(pick("Change Type"));
+            let vDue        = stripMd(pick("Due Date"));
+            if (emptyLike(vDue)) vDue = "";
+
+            // 폼이 비어 있으면 프로젝트 칩 값으로 보강
+            if (!vPriority)   vPriority   = currentPriority;
+            if (!vComponent)  vComponent  = currentComponent;
+            if (!vChangeType) vChangeType = currentChangeType;
+
+            // ---------- 5) Due Date 결정 ----------
+            let finalDue = currentDue || "";
+            let isoDue = "";
+            if (isISO(vDue)) {
+              isoDue = vDue;
+            } else if (!vDue && !currentDue) {
+              isoDue = KST_TODAY();
+              ops.push(`ℹ️ Due Date empty → defaulting to ${isoDue} (KST today)`);
+            }
+            if (isoDue && isoDue !== currentDue) {
+              if (fDue?.id) {
+                await gql(`
+                  mutation($pid:ID!,$item:ID!,$fid:ID!,$date:Date!){
+                    updateProjectV2ItemFieldValue(input:{
+                      projectId:$pid, itemId:$item, fieldId:$fid, value:{ date:$date }
+                    }){ projectV2Item { id } }
+                  }`, { pid: project.id, item: itemId, fid: fDue.id, date: isoDue });
+                ops.push(`🔁 Due Date → ${isoDue}`);
+                finalDue = isoDue;
+              } else {
+                ops.push(`⚠️ Due Date field "${process.env.DUEDATE_FIELD_NAME}" not found, skipped update`);
+              }
+            } else {
+              finalDue = currentDue;
+            }
+
+            // ---------- 6) 나머지 필드 동기화 ----------
+            const maybeUpdateSelect = async (field, valueText, currentText, label) => {
+              if (!field?.options?.length || !valueText) return;
+              if (valueText === currentText) { ops.push(`✓ ${label} unchanged (${currentText || "-"})`); return; }
+              const opt = field.options.find(o => o.name === valueText);
+              if (!opt) { ops.push(`⚠️ ${label}: option "${valueText}" not found`); return; }
+              await gql(`
+                mutation($pid:ID!,$item:ID!,$fid:ID!,$opt:ID!){
+                  updateProjectV2ItemFieldValue(input:{
+                    projectId:$pid, itemId:$item, fieldId:$fid, value:{ singleSelectOptionId:$opt }
+                  }){ projectV2Item { id } }
+                }`, { pid: project.id, item: itemId, fid: field.id, opt: opt.id });
+              ops.push(`🔁 ${label} → ${valueText}`);
+            };
+
+            await maybeUpdateSelect(fPriority,   vPriority,   currentPriority,   "Priority");
+            await maybeUpdateSelect(fComponent,  vComponent,  currentComponent,  "Component");
+            await maybeUpdateSelect(fChangeType, vChangeType, currentChangeType, "Change Type");
+
+            // ---------- 7) Summary / D-Day ----------
+            const prMap = { Critical:"🔥 Critical", High:"🚨 High", Medium:"⚖️ Medium", Low:"💤 Low" };
+            const ctMap = { feat:"🌟 feat", fix:"🛠 fix", refactor:"♻️ refactor", docs:"📝 docs", perf:"⚡ perf",
+                            chore:"🧹 chore", test:"✅ test", ci:"🤖 ci", build:"📦 build", revert:"↩️ revert" };
+            const pieces = [];
+            if (vChangeType) pieces.push(ctMap[vChangeType] || `🏷 ${vChangeType}`);
+            if (vComponent)  pieces.push(`🧩 ${vComponent}`);
+            if (vPriority)   pieces.push(prMap[vPriority] || vPriority);
+            if (finalDue)    pieces.push(`⏰ ${finalDue} (${ddayLabel(diffDaysKST(finalDue))})`);
+
+            const summaryText = pieces.join(" · ");
+            const updateText = async (field, text, label) => {
+              if (!field || !text) return;
+              await gql(`
+                mutation($pid:ID!,$item:ID!,$fid:ID!,$txt:String!){
+                  updateProjectV2ItemFieldValue(input:{
+                    projectId:$pid, itemId:$item, fieldId:$fid, value:{ text:$txt }
+                  }){ projectV2Item { id } }
+                }`, { pid: project.id, item: itemId, fid: field.id, txt: text });
+              ops.push(`🔁 ${label} → ${text}`);
+            };
+            if (fSummary && summaryText) await updateText(fSummary, summaryText, process.env.SUMMARY_FIELD_NAME);
+            if (fDDay) {
+              const d = finalDue ? ddayLabel(diffDaysKST(finalDue)) : "";
+              if (d) await updateText(fDDay, d, process.env.DDAY_FIELD_NAME);
+            }
+
+            // ---------- 8) Summary 코멘트 업서트 ----------
+            const marker = "<!-- project-sync-summary -->";
+            const prettyDate = finalDue
+              ? new Intl.DateTimeFormat("en-US", { month:"short", day:"numeric", year:"numeric", timeZone:"Asia/Seoul" })
+                  .format(new Date(finalDue+"T00:00:00+09:00"))
+              : "";
+            const mdLines = [
+              marker,
+              "### 🧾 Summary",
+              `- **Priority:** ${vPriority || "_(none)_"}`,
+              `- **Component:** ${vComponent || "_(none)_"}`,
+              `- **Change Type:** ${vChangeType || "_(none)_"}`,
+              `- **Due Date:** ${finalDue ? `${prettyDate} (${ddayLabel(diffDaysKST(finalDue))})` : "_(none)_"}`,
+              "",
+              "> 필드는 프로젝트 카드에도 동기화됩니다. 폼/프로젝트가 비어 있으면 Due Date는 KST 오늘로 기본 설정됩니다.",
+              marker
+            ];
+            const md = mdLines.join("\n");
+
+            const list = await github.rest.issues.listComments({ owner, repo, issue_number: issue.number, per_page: 100 });
+            const existing = (list.data || []).find(c => (c.body || "").includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body: md });
+              ops.push("📝 Updated summary comment");
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: md });
+              ops.push("📝 Created summary comment");
+            }
+
+            // ---------- 9) 본문 tidy (opened 시 1회) ----------
+            if (context.eventName === "issues" && context.payload.action === "opened") {
+              const tidyMarker = "<!-- project-sync-tidied -->";
+              const { data: fresh } = await github.rest.issues.get({ owner, repo, issue_number: issue.number });
+              let ibody = fresh.body || "";
+              if (!ibody.includes(tidyMarker)) {
+                const stripSection = (src, label) =>
+                  src.replace(
+                    new RegExp(`(^|\\n)###\\s*${label}\\s*\\r?\\n+[\\s\\S]*?(?=(\\n###\\s)|$)`, "m"),
+                    (m, p1) => (p1 ? p1 : "")
+                  ).trim();
+                const SECTIONS = ["Priority", "Component", "Change Type", "Due Date"];
+                let newBody = ibody;
+                for (const sec of SECTIONS) newBody = stripSection(newBody, sec);
+                const notice = [
+                  tidyMarker,
+                  "> ℹ️  상단 폼 섹션은 숨기고 아래 **Summary**에서 핵심만 보여줍니다.",
+                  "> 상세 서술은 **Details** 섹션을 사용하세요.",
+                  ""
+                ].join("\n");
+                newBody = `${notice}${newBody}`;
+                await github.rest.issues.update({ owner, repo, issue_number: issue.number, body: newBody });
+                ops.push("🧹 Tidied issue body (hid form sections)");
+              }
+            }
+
+            // ---------- 10) 로그 ----------
+            console.log(ops.length ? ops.join('\n') : 'No field changes.');

--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,12 @@ node_modules
 ### REST Docs 출력 디렉토리 ###
 !src/docs/
 
-### GitAction 출력 디렉토리 ###
+### GitAction/Issue Template 화이트리스트 ###
 !.github/
 !.github/workflows/
-!.github/workflows/*
+!.github/workflows/*.yml
+!.github/ISSUE_TEMPLATE/
+!.github/ISSUE_TEMPLATE/*.yml
 
 ### k6 성능 테스트 디렉토리 ###
 k6-load-test/


### PR DESCRIPTION
## 요약
Org Projects 보드 **#2 (pinup-team)** 운영 자동화를 추가합니다.  
이슈 템플릿으로 메타(우선순위/도메인/변경유형/마감일)를 받고, 두 개의 워크플로가
- 신규 이슈/PR을 **프로젝트 보드(#2)**에 자동 추가
- 폼 값 → **프로젝트 커스텀 필드**에 동기화(+ Summary/D-Day, 요약 코멘트, tidy)

---

## 변경 내용
- `.github/ISSUE_TEMPLATE/work-item.yml` 추가 (이슈 폼)
- `.github/workflows/add-to-project.yml` 추가 (보드 자동 추가)
- `.github/workflows/project-fields-from-form.yml` 추가 (필드 동기화)
- `.gitignore`에 예외 추가: `.github/`, `.github/workflows/*.yml`, `.github/ISSUE_TEMPLATE/*.yml` 추적 허용

---

## 파일별 설명

### 1) 이슈 폼 — `.github/ISSUE_TEMPLATE/work-item.yml`
- **용도:** 카드에 보일 **칩 4종** 수집: `Priority`, `Component`, `Change Type`, `Due Date`
- **필수 본문:** `Details` (무엇/왜/어떻게/영향/테스트/롤백 가이드)
- **Due Date 규칙:** 비워두면 동기화 워크플로가 **KST ‘오늘’**로 1회 자동 설정
- **칩 설계:** 보드 `Customize cards`에서 위 4개 + (선택) `Summary`, `D-Day` 표시

### 2) 프로젝트 자동 추가 — `.github/workflows/add-to-project.yml`
- **역할:** 새 **이슈/PR** 생성 시 Org Project **#2**에 아이템 자동 추가
- **트리거:** `issues.opened|reopened|edited|transferred`, `pull_request.opened|reopened|ready_for_review`
- **설정:**  
  - `project-url: https://github.com/orgs/pinup-team/projects/2`  
  - `github-token: ${{ secrets.PROJECTS_TOKEN }}`  ← classic PAT (scopes: `repo`, `project`, `read:org`)
- **비고:** Org Projects(v2) 쓰기 권한은 `GITHUB_TOKEN`만으로 부족 → **PAT 시크릿** 필요

### 3) 폼 → 프로젝트 필드 동기화 — `.github/workflows/project-fields-from-form.yml`
- **역할:** 이슈 폼 값을 **프로젝트 커스텀 필드**로 반영  
  - `Priority / Component / Change Type` → Single select  
  - `Due Date` → Date (없으면 KST 오늘)  
  - *(선택)* `Summary`(한 줄 요약 칩), `D-Day`(D-3/D-Day/D+1 …) 텍스트 필드 채움
- **부가 기능:** 이슈에 `🧾 Summary` 코멘트 **업서트**, 폼 섹션 **tidy**(본문 상단 가림)
- **핵심 ENV:**  
  - `ORG="pinup-team"`, `PROJECT_NUMBER="2"`  
  - `PRIORITY_FIELD_NAME="Priority"`, `COMPONENT_FIELD_NAME="Component"`  
  - `CHANGE_TYPE_FIELD_NAME="Change Type"`, `DUEDATE_FIELD_NAME="Due Date"`  
  - *(선택)* `SUMMARY_FIELD_NAME="Summary"`, `DDAY_FIELD_NAME="D-Day"`
- **보호 로직:** 필드 미존재/옵션 불일치 시 안전 로그만 남기고 스킵

---

## 보안/권한
- **시크릿:** `PROJECTS_TOKEN`(classic PAT, scopes: `repo`, `project`, `read:org`)  
- **SSO:** 조직에서 SAML 강제 시, 토큰 생성 후 **Configure SSO → pinup-team Authorize** 필요
- **Org Secret 범위:** Selected repositories에 `pinup` 포함 권장(최소 권한)

---

## 어떻게 테스트하나요? (스모크)
1. Projects **#2** → `Add item → Create new issue`  
   - 템플릿: **Work Item (Tables)**  
   - 값 예시: `Priority=High`, `Component=posts`, `Change Type=feat`, **Due Date 비움**, `Details` 임의
2. 기대 결과  
   - 카드가 보드에 **자동 추가**  
   - 카드 칩: **Priority / Due Date / Change Type / Component** 채워짐  
   - 이슈에 **🧾 Summary 코멘트** 생성 + 본문 상단 폼 섹션 tidy  
3. Actions 탭  
   - `Add new items to Org Project` = ✅ Success  
   - `Sync issue form to Project fields (ORG)` = ✅ Success

---

## 롤백 플랜
- 문제 발생 시 이 PR **Revert**  
- 필요 시 `PROJECTS_TOKEN` **Revoke** 후 재발급/재등록  
- Projects 내장 자동화(Workflows) 일시 OFF 가능

---

## 체크리스트
- [ ] Org Projects 보드 **#2**에서 커스텀 필드 생성(이름/타입 철자 일치)
- [ ] Org Secret `PROJECTS_TOKEN` 설정 및 SSO 승인 완료
- [ ] 기본 브랜치(main)에 템플릿/워크플로 노출됨
- [ ] 스모크 테스트 통과(칩/코멘트/로그 확인)
