### PR TITLE
fix(ci): Projects single-select 업데이트 타입 수정 (ID! → String!)

### DIFF
--- a/.github/workflows/project-fields-from-form.yml
+++ b/.github/workflows/project-fields-from-form.yml
@@ -212,12 +212,13 @@ jobs:
               if (valueText === currentText) { ops.push(`✓ ${label} unchanged (${currentText || "-"})`); return; }
               const opt = field.options.find(o => o.name === valueText);
               if (!opt) { ops.push(`⚠️ ${label}: option "${valueText}" not found`); return; }
+              // ✅ FIX: $opt 타입을 String! 으로 선언 (이전 오류: ID! / String 미스매치)
               await gql(`
-                mutation($pid:ID!,$item:ID!,$fid:ID!,$opt:ID!){
+                mutation($pid:ID!,$item:ID!,$fid:ID!,$opt:String!){
                   updateProjectV2ItemFieldValue(input:{
                     projectId:$pid, itemId:$item, fieldId:$fid, value:{ singleSelectOptionId:$opt }
                   }){ projectV2Item { id } }
-                }`, { pid: project.id, item: itemId, fid: field.id, opt: opt.id });
+                }`, { pid: project.id, item: itemId, fid: field.id, opt: opt.id }); // opt.id는 GraphQL에서 받은 "옵션 노드 ID(문자열)"
               ops.push(`🔁 ${label} → ${valueText}`);
             };
 


### PR DESCRIPTION
fix(ci): Projects single-select 업데이트 타입 수정 (ID! → String!)

## 요약
GraphQL singleSelectOptionId 타입 미스매치(ID! / String) 해결.

## 작업 내용
- mutation 변수 \$opt 타입을 ID! → String! 으로 변경

## 참고 사항
- singleSelectOptionId에는 옵션의 node ID 문자열을 전달해야 합니다.

## 관련 이슈
- Close #이슈번호
