### PR TITLE
fix : activeprofiles 추가

### DIFF
--- a/src/test/java/kr/co/pinup/members/MemberRepositoryTest.java
+++ b/src/test/java/kr/co/pinup/members/MemberRepositoryTest.java
@@ -10,12 +10,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class MemberRepositoryTest {
 
     @Autowired

--- a/src/test/java/kr/co/pinup/verification/VerificationRepositoryTest.java
+++ b/src/test/java/kr/co/pinup/verification/VerificationRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@EnableJpaAuditing
 @ActiveProfiles("test")
 public class VerificationRepositoryTest {
 

--- a/src/test/java/kr/co/pinup/verification/VerificationRepositoryTest.java
+++ b/src/test/java/kr/co/pinup/verification/VerificationRepositoryTest.java
@@ -1,6 +1,5 @@
 package kr.co.pinup.verification;
 
-import jakarta.persistence.EntityManager;
 import kr.co.pinup.verification.repository.VerificationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,16 +20,13 @@ public class VerificationRepositoryTest {
     @Autowired
     private VerificationRepository verificationRepository;
 
-    @Autowired
-    private EntityManager entityManager;
-
     private Verification verification;
 
     @BeforeEach
     void setUp() {
         verification = new Verification("test@pinup.com", "12345", LocalDateTime.now().plusMinutes(5));
         verificationRepository.save(verification);
-        entityManager.flush();
+        verificationRepository.flush();
     }
 
     @Test
@@ -45,7 +41,6 @@ public class VerificationRepositoryTest {
     @DisplayName("이메일로 Verification 삭제 테스트")
     void deleteByEmailTest() {
         verificationRepository.deleteByEmail("test@pinup.com");
-        entityManager.flush();
 
         Optional<Verification> found = verificationRepository.findByEmail("test@pinup.com");
         assertFalse(found.isPresent());

--- a/src/test/java/kr/co/pinup/verification/VerificationRepositoryTest.java
+++ b/src/test/java/kr/co/pinup/verification/VerificationRepositoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@ActiveProfiles("test")
 public class VerificationRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## 요약
- 타 기기 테스트 오류로 ActiveProfiles, EnableJpaAuditing 추가

## 작업 내용
- MemberRepositoryTest, VerificationRepositoryTest 에 ActiveProfiles test로 지정
- 테스트에서 Entity 생성 시 @CreatedDate, @LastModifiedDate 필드 등을 초기화하기 위해서 AuditingEntityListener가 필요하므로 @EnableJpaAuditing 추가

- Close #이슈번호