### PR TITLE
[feat] Spring Cache(Caffeine) 도입 — 화이트리스트 기반 Strict + after-commit 이벤트 무효화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,10 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
 	implementation 'org.springframework.retry:spring-retry'
+
+    // Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/pinup/cache/AppCacheProps.java
+++ b/src/main/java/kr/co/pinup/cache/AppCacheProps.java
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.Map;
 
-@ConfigurationProperties(prefix =  "spring.cache.app")
+@ConfigurationProperties(prefix ="spring.cache.app")
 public record AppCacheProps(
         Defaults defaults,
         Map<String, Spec> caches

--- a/src/main/java/kr/co/pinup/cache/AppCacheProps.java
+++ b/src/main/java/kr/co/pinup/cache/AppCacheProps.java
@@ -1,0 +1,14 @@
+package kr.co.pinup.cache;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+
+@ConfigurationProperties(prefix =  "spring.cache.app")
+public record AppCacheProps(
+        Defaults defaults,
+        Map<String, Spec> caches
+) {
+    public record Defaults(Long maximumSize, Integer ttlSec) {}
+    public record Spec(Long maximumSize, Integer ttlSec) {}
+}

--- a/src/main/java/kr/co/pinup/cache/CacheNames.java
+++ b/src/main/java/kr/co/pinup/cache/CacheNames.java
@@ -1,0 +1,6 @@
+package kr.co.pinup.cache;
+
+public interface CacheNames {
+    String POST_DETAIL = "post:detail";
+    String POST_IMAGES = "post:images";
+}

--- a/src/main/java/kr/co/pinup/cache/listener/PostCacheInvalidationListener.java
+++ b/src/main/java/kr/co/pinup/cache/listener/PostCacheInvalidationListener.java
@@ -1,0 +1,42 @@
+package kr.co.pinup.cache.listener;
+
+import kr.co.pinup.cache.CacheNames;
+import kr.co.pinup.posts.event.PostCacheEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PostCacheInvalidationListener {
+
+    private final CacheManager cacheManager;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PostCacheEvent e) {
+        switch (e.kind()) {
+            case UPDATED -> {
+                if (e.detailChanged()) {
+                    var d = cacheManager.getCache(CacheNames.POST_DETAIL);
+                    if (d != null) d.evict(e.postId());
+                }
+                if (e.imagesChanged()) {
+                    var i = cacheManager.getCache(CacheNames.POST_IMAGES);
+                    if (i != null) i.evict(e.postId());
+                }
+            }
+            case DISABLED -> {
+                var d = cacheManager.getCache(CacheNames.POST_DETAIL);
+                if (d != null) d.evict(e.postId());
+            }
+            case DELETED -> {
+                var d = cacheManager.getCache(CacheNames.POST_DETAIL);
+                if (d != null) d.evict(e.postId());
+                var i = cacheManager.getCache(CacheNames.POST_IMAGES);
+                if (i != null) i.evict(e.postId());
+            }
+        }
+    }
+}

--- a/src/main/java/kr/co/pinup/cache/listener/PostCacheInvalidationListener.java
+++ b/src/main/java/kr/co/pinup/cache/listener/PostCacheInvalidationListener.java
@@ -3,6 +3,7 @@ package kr.co.pinup.cache.listener;
 import kr.co.pinup.cache.CacheNames;
 import kr.co.pinup.posts.event.PostCacheEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -15,28 +16,30 @@ public class PostCacheInvalidationListener {
     private final CacheManager cacheManager;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void on(PostCacheEvent e) {
-        switch (e.kind()) {
+    public void on(PostCacheEvent event) {
+        switch (event.kind()) {
             case UPDATED -> {
-                if (e.detailChanged()) {
-                    var d = cacheManager.getCache(CacheNames.POST_DETAIL);
-                    if (d != null) d.evict(e.postId());
+                if (event.detailChanged()) {
+                    evictIfPresent(CacheNames.POST_DETAIL, event.postId());
                 }
-                if (e.imagesChanged()) {
-                    var i = cacheManager.getCache(CacheNames.POST_IMAGES);
-                    if (i != null) i.evict(e.postId());
+                if (event.imagesChanged()) {
+                    evictIfPresent(CacheNames.POST_IMAGES, event.postId());
                 }
             }
             case DISABLED -> {
-                var d = cacheManager.getCache(CacheNames.POST_DETAIL);
-                if (d != null) d.evict(e.postId());
+                evictIfPresent(CacheNames.POST_DETAIL, event.postId());
             }
             case DELETED -> {
-                var d = cacheManager.getCache(CacheNames.POST_DETAIL);
-                if (d != null) d.evict(e.postId());
-                var i = cacheManager.getCache(CacheNames.POST_IMAGES);
-                if (i != null) i.evict(e.postId());
+                evictIfPresent(CacheNames.POST_DETAIL, event.postId());
+                evictIfPresent(CacheNames.POST_IMAGES, event.postId());
             }
+        }
+    }
+
+    private void evictIfPresent(String cacheName, Object key) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.evict(key);
         }
     }
 }

--- a/src/main/java/kr/co/pinup/config/CacheConfig.java
+++ b/src/main/java/kr/co/pinup/config/CacheConfig.java
@@ -15,10 +15,9 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager(AppCacheProps props) {
-        // per-cache 정책을 주입하려면 익명 클래스로 createCaffeineCache를 오버라이드
+
         return new CaffeineCacheManager() {
             {
-                // strict: 선언되지 않은 캐시는 사용 불가
                 setAllowNullValues(false);
                 setCacheNames(props.caches().keySet());
             }
@@ -27,10 +26,9 @@ public class CacheConfig {
             protected CaffeineCache createCaffeineCache(String name) {
                 Caffeine<Object, Object> builder = Caffeine.newBuilder().recordStats();
 
-                var d = props.defaults();        // 기본 정책
-                var s = props.caches().get(name); // 캐시별 오버라이드
+                var d = props.defaults();
+                var s = props.caches().get(name);
 
-                // 1) 유효값을 먼저 계산(오버라이드 우선)
                 Long maxSize = (s != null && s.maximumSize() != null)
                         ? s.maximumSize()
                         : (d != null ? d.maximumSize() : null);
@@ -39,13 +37,8 @@ public class CacheConfig {
                         ? s.ttlSec()
                         : (d != null ? d.ttlSec() : null);
 
-                // 2) 계산된 값만 "한 번씩" 세팅
-                if (maxSize != null) {
-                    builder = builder.maximumSize(maxSize);
-                }
-                if (ttlSec != null) {
-                    builder = builder.expireAfterWrite(java.time.Duration.ofSeconds(ttlSec));
-                }
+                if (maxSize != null) builder = builder.maximumSize(maxSize);
+                if (ttlSec != null) builder = builder.expireAfterWrite(java.time.Duration.ofSeconds(ttlSec));
 
                 return new org.springframework.cache.caffeine.CaffeineCache(name, builder.build(), false);
             }

--- a/src/main/java/kr/co/pinup/config/CacheConfig.java
+++ b/src/main/java/kr/co/pinup/config/CacheConfig.java
@@ -40,7 +40,7 @@ public class CacheConfig {
                 if (maxSize != null) builder = builder.maximumSize(maxSize);
                 if (ttlSec != null) builder = builder.expireAfterWrite(java.time.Duration.ofSeconds(ttlSec));
 
-                return new org.springframework.cache.caffeine.CaffeineCache(name, builder.build(), false);
+                return new CaffeineCache(name, builder.build(), false);
             }
 
         };

--- a/src/main/java/kr/co/pinup/config/CacheConfig.java
+++ b/src/main/java/kr/co/pinup/config/CacheConfig.java
@@ -1,0 +1,55 @@
+package kr.co.pinup.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import kr.co.pinup.cache.AppCacheProps;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AppCacheProps.class)
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(AppCacheProps props) {
+        // per-cache 정책을 주입하려면 익명 클래스로 createCaffeineCache를 오버라이드
+        return new CaffeineCacheManager() {
+            {
+                // strict: 선언되지 않은 캐시는 사용 불가
+                setAllowNullValues(false);
+                setCacheNames(props.caches().keySet());
+            }
+
+            @Override
+            protected CaffeineCache createCaffeineCache(String name) {
+                Caffeine<Object, Object> builder = Caffeine.newBuilder().recordStats();
+
+                var d = props.defaults();        // 기본 정책
+                var s = props.caches().get(name); // 캐시별 오버라이드
+
+                // 1) 유효값을 먼저 계산(오버라이드 우선)
+                Long maxSize = (s != null && s.maximumSize() != null)
+                        ? s.maximumSize()
+                        : (d != null ? d.maximumSize() : null);
+
+                Integer ttlSec = (s != null && s.ttlSec() != null)
+                        ? s.ttlSec()
+                        : (d != null ? d.ttlSec() : null);
+
+                // 2) 계산된 값만 "한 번씩" 세팅
+                if (maxSize != null) {
+                    builder = builder.maximumSize(maxSize);
+                }
+                if (ttlSec != null) {
+                    builder = builder.expireAfterWrite(java.time.Duration.ofSeconds(ttlSec));
+                }
+
+                return new org.springframework.cache.caffeine.CaffeineCache(name, builder.build(), false);
+            }
+
+        };
+    }
+}

--- a/src/main/java/kr/co/pinup/postImages/repository/PostImageRepository.java
+++ b/src/main/java/kr/co/pinup/postImages/repository/PostImageRepository.java
@@ -12,6 +12,8 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 
     List<PostImage> findByPostId(Long postId);
 
+    List<PostImage> findAllByPostIdOrderByIdAsc(Long postId);
+
     void deleteAllByPostId(Long postId);
 
     List<PostImage> findByPostIdAndS3UrlIn(Long id, List<String> images);

--- a/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
+++ b/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
@@ -1,33 +1,28 @@
 package kr.co.pinup.postImages.service;
 
 import kr.co.pinup.cache.CacheNames;
-import kr.co.pinup.custom.s3.exception.ImageDeleteFailedException;
-import kr.co.pinup.postImages.model.dto.PostImageUploadRequest;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
-
 import kr.co.pinup.custom.logging.AppLogger;
 import kr.co.pinup.custom.logging.model.dto.ErrorLog;
 import kr.co.pinup.custom.logging.model.dto.InfoLog;
 import kr.co.pinup.custom.logging.model.dto.WarnLog;
 import kr.co.pinup.custom.s3.S3Service;
-
 import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageDeleteFailedException;
 import kr.co.pinup.postImages.exception.postimage.PostImageNotFoundException;
 import kr.co.pinup.postImages.exception.postimage.PostImageSaveFailedException;
 import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
 import kr.co.pinup.postImages.model.dto.PostImageResponse;
-
 import kr.co.pinup.postImages.model.dto.UpdatePostImageRequest;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.posts.Post;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
+++ b/src/main/java/kr/co/pinup/postImages/service/PostImageService.java
@@ -1,7 +1,9 @@
 package kr.co.pinup.postImages.service;
 
+import kr.co.pinup.cache.CacheNames;
 import kr.co.pinup.custom.s3.exception.ImageDeleteFailedException;
 import kr.co.pinup.postImages.model.dto.PostImageUploadRequest;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -173,6 +175,11 @@ public class PostImageService  {
         }
     }
 
+    @Cacheable(
+            value = CacheNames.POST_IMAGES,
+            key = "#p0",  // postId
+            sync = true
+    )
     @Transactional(readOnly = true)
     public List<PostImageResponse> findImagesByPostId(Long postId) {
         log.debug("이미지 목록 조회: postId={}", postId);

--- a/src/main/java/kr/co/pinup/posts/event/PostCacheEvent.java
+++ b/src/main/java/kr/co/pinup/posts/event/PostCacheEvent.java
@@ -8,7 +8,6 @@ public record PostCacheEvent(
 ) {
     public enum Kind { UPDATED, DISABLED, DELETED }
 
-    // 의도 명확한 팩토리 메서드
     public static PostCacheEvent updated(Long postId, boolean detailChanged, boolean imagesChanged) {
         return new PostCacheEvent(postId, Kind.UPDATED, detailChanged, imagesChanged);
     }

--- a/src/main/java/kr/co/pinup/posts/event/PostCacheEvent.java
+++ b/src/main/java/kr/co/pinup/posts/event/PostCacheEvent.java
@@ -1,0 +1,21 @@
+package kr.co.pinup.posts.event;
+
+public record PostCacheEvent(
+        Long postId,
+        Kind kind,
+        boolean detailChanged,   // UPDATED일 때만 의미
+        boolean imagesChanged    // UPDATED일 때만 의미
+) {
+    public enum Kind { UPDATED, DISABLED, DELETED }
+
+    // 의도 명확한 팩토리 메서드
+    public static PostCacheEvent updated(Long postId, boolean detailChanged, boolean imagesChanged) {
+        return new PostCacheEvent(postId, Kind.UPDATED, detailChanged, imagesChanged);
+    }
+    public static PostCacheEvent disabled(Long postId) {
+        return new PostCacheEvent(postId, Kind.DISABLED, false, false);
+    }
+    public static PostCacheEvent deleted(Long postId) {
+        return new PostCacheEvent(postId, Kind.DELETED, false, false);
+    }
+}

--- a/src/main/java/kr/co/pinup/posts/service/PostService.java
+++ b/src/main/java/kr/co/pinup/posts/service/PostService.java
@@ -1,5 +1,6 @@
 package kr.co.pinup.posts.service;
 
+import kr.co.pinup.cache.CacheNames;
 import kr.co.pinup.custom.logging.AppLogger;
 import kr.co.pinup.custom.logging.model.dto.ErrorLog;
 import kr.co.pinup.custom.logging.model.dto.InfoLog;
@@ -12,8 +13,10 @@ import kr.co.pinup.postImages.exception.postimage.PostImageUpdateCountException;
 import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
 import kr.co.pinup.postImages.model.dto.PostImageResponse;
 import kr.co.pinup.postImages.model.dto.UpdatePostImageRequest;
+import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.postImages.service.PostImageService;
 import kr.co.pinup.posts.Post;
+import kr.co.pinup.posts.event.PostCacheEvent;
 import kr.co.pinup.posts.exception.post.PostDeleteFailedException;
 import kr.co.pinup.posts.exception.post.PostNotFoundException;
 import kr.co.pinup.posts.model.dto.CreatePostRequest;
@@ -25,6 +28,8 @@ import kr.co.pinup.stores.exception.StoreNotFoundException;
 import kr.co.pinup.stores.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -43,7 +48,10 @@ public class PostService {
     private final PostImageService postImageService;
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
-    private final AppLogger appLogger;
+    private final PostImageRepository postImageRepository;
+    private final AppLogger appLogger ;
+    private final ApplicationEventPublisher events;
+
 
     private record ChangeFlags(boolean hasText, boolean hasUpload, boolean hasDelete) {
     }
@@ -111,6 +119,12 @@ public class PostService {
 
     }
 
+    @Cacheable(
+            value = CacheNames.POST_DETAIL,
+            key = "#p0",
+            condition = "!#p1",
+            sync = true
+    )
     @Transactional(readOnly = true)
     public PostResponse getPostById(Long id, boolean isDeleted) {
         log.debug("게시글 단건 요청: postId={}, isDeleted={}", id, isDeleted);
@@ -133,6 +147,7 @@ public class PostService {
         }
         try {
             postRepository.delete(post);
+            events.publishEvent(PostCacheEvent.deleted(postId));
             appLogger.info(new InfoLog("게시글 삭제 성공").setStatus("200").setTargetId(postId.toString()));
         } catch (Exception e) {
             appLogger.error(new ErrorLog("게시글 삭제 실패", e)
@@ -148,6 +163,7 @@ public class PostService {
         post.disablePost(true);
         appLogger.info(new InfoLog("게시글 비활성화 처리").setStatus("200").setTargetId(postId.toString()));
         postRepository.save(post);
+        events.publishEvent(PostCacheEvent.disabled(postId));
     }
 
     public Post findByIdOrThrow(Long id) {
@@ -235,6 +251,8 @@ public class PostService {
             if (!actuallyDeleted.isEmpty()) {
                 postImageService.deleteS3QuietlyAfterCommit(actuallyDeleted);
             }
+            if (imagesChanged ) {
+                events.publishEvent(PostCacheEvent.updated(id, /*detailChanged*/ false, /*imagesChanged*/ true));            }
             return PostResponse.from(post);
         }
 
@@ -249,6 +267,10 @@ public class PostService {
             if (!actuallyDeleted.isEmpty()) {
                 postImageService.deleteS3QuietlyAfterCommit(actuallyDeleted);
             }
+            events.publishEvent(PostCacheEvent.updated(
+                    id,
+                    /* detailChanged */  (textChanged || thumbChanged),/* imagesChanged */  (imagesChanged || thumbChanged)
+            ));
         }
     }
 
@@ -277,7 +299,7 @@ public class PostService {
     private boolean refreshThumbnailIfNeeded(Post post, Long postId, boolean imagesChanged) {
         if (!imagesChanged) return false;
 
-        List<PostImageResponse> remaining = postImageService.findImagesByPostId(postId);
+        List<PostImage> remaining = postImageRepository.findAllByPostIdOrderByIdAsc(postId);
         if (remaining.size() < 2) throw new PostImageUpdateCountException();
 
         String current = post.getThumbnail();

--- a/src/main/java/kr/co/pinup/posts/service/PostService.java
+++ b/src/main/java/kr/co/pinup/posts/service/PostService.java
@@ -11,7 +11,6 @@ import kr.co.pinup.members.repository.MemberRepository;
 import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageUpdateCountException;
 import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
-import kr.co.pinup.postImages.model.dto.PostImageResponse;
 import kr.co.pinup.postImages.model.dto.UpdatePostImageRequest;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.postImages.service.PostImageService;

--- a/src/test/java/kr/co/pinup/posts/PostIntegrationTest.java
+++ b/src/test/java/kr/co/pinup/posts/PostIntegrationTest.java
@@ -1,6 +1,8 @@
 package kr.co.pinup.posts;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import kr.co.pinup.cache.listener.PostCacheInvalidationListener;
+import kr.co.pinup.config.CacheConfig;
 import kr.co.pinup.config.S3ClientConfig;
 import kr.co.pinup.locations.Location;
 import kr.co.pinup.locations.reposiotry.LocationRepository;
@@ -38,6 +40,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.ui.ModelMap;
@@ -68,8 +71,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
-@Transactional
-@Import({S3ClientConfig.class, PostIntegrationTest.TestMockConfig.class})
+@Import({S3ClientConfig.class, PostIntegrationTest.TestMockConfig.class,   CacheConfig.class, PostCacheInvalidationListener.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PostIntegrationTest {
 
@@ -379,6 +381,7 @@ public class PostIntegrationTest {
         }
 
         @Test
+        @Transactional(propagation = Propagation.NOT_SUPPORTED)
         @DisplayName("제목만 수정하고 이미지 1개만 삭제할 경우 예외가 발생하고 기존 상태가 유지된다(현행 동작 기준)")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void updatePost_whenTitleAndDeleteImages_thenThrowsExceptionAndRollback() throws Exception {
@@ -405,21 +408,23 @@ public class PostIntegrationTest {
                     });
 
             // Then (서비스 수정 없음, 현행 동작 기준):
-            // - 이미지 삭제(DB)는 별도 트랜잭션으로 커밋되어 1장만 남음
-            // - 썸네일은 저장되지 않아 '삭제된 URL'이 남아있거나, 구현차로 남은 URL일 수도 있음 (둘 다 허용)
-            // - S3는 afterCommit 예약이 없어서 두 객체 모두 여전히 존재
-            Post post = postRepository.findById(postId).orElseThrow();
+            Post post = postRepository.findById(postId)
+                    .orElseThrow(() -> new AssertionError("게시글이 존재해야 함"));
+
             List<PostImage> currentImages = postImageRepository.findByPostId(postId);
             List<String> currentUrls = currentImages.stream().map(PostImage::getS3Url).toList();
 
-            assertThat(currentUrls).containsExactly(remainingUrl); // DB에는 1장만 남음
+            assertThat(currentUrls)
+                    .as("내부 REQUIRES_NEW 커밋으로 1장만 남음(현행 동작)")
+                    .containsExactly(remainingUrl);
 
-            // 썸네일은 삭제된 URL이 그대로일 가능성이 높음(저장 안 됨). 둘 다 허용.
-            assertThat(post.getThumbnail()).isIn(deleteTargetUrl, remainingUrl);
+            assertThat(post.getThumbnail())
+                    .as("썸네일은 롤백되어 기존 상태 유지")
+                    .isIn(deleteTargetUrl, remainingUrl);
 
-            // S3는 둘 다 아직 존재해야 함
             assertS3ObjectExists(extractS3Key(deleteTargetUrl));
             assertS3ObjectExists(extractS3Key(remainingUrl));
+
         }
 
     }
@@ -704,7 +709,8 @@ public class PostIntegrationTest {
                         .param("thumbnail", thumbnailName)
                         .with(csrf()))
                 .andExpect(status().isCreated());
-
+        postRepository.flush();
+        postImageRepository.flush();
         return postRepository.findAll().get(0).getId();
     }
 

--- a/src/test/java/kr/co/pinup/posts/PostIntegrationTest.java
+++ b/src/test/java/kr/co/pinup/posts/PostIntegrationTest.java
@@ -49,16 +49,16 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
-import static org.awaitility.Awaitility.await;
-import java.time.Duration;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -170,7 +170,7 @@ public class PostIntegrationTest {
         @DisplayName("정상적으로 게시글이 생성되고 모든 흐름이 작동한다")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void createPost_thenFlowComplete() throws Exception {
-            // Given: 이미지 파일과 게시글 정보가 주어짐
+            // Given
             MockMultipartFile image1 = new MockMultipartFile("images", "img1.jpg", "image/jpeg", "data1".getBytes());
             MockMultipartFile image2 = new MockMultipartFile("images", "img2.jpg", "image/jpeg", "data2".getBytes());
 
@@ -185,18 +185,18 @@ public class PostIntegrationTest {
                     "post", "post.json", "application/json", json.getBytes(StandardCharsets.UTF_8)
             );
 
-            // When: 게시글 생성 요청
+            // When
             mockMvc.perform(multipart("/api/post/create")
                             .file(image1)
                             .file(image2)
                             .file(postPart)
                             .with(csrf()))
-                    // Then: 응답이 성공이고 JSON 응답이 예상한 값과 일치함
+                    // Then
                     .andExpect(status().isCreated())
                     .andExpect(jsonPath("$.title").value("테스트 제목"))
                     .andExpect(jsonPath("$.thumbnail").value(containsString("img1.jpg")));
 
-            // And: DB 및 S3 상태 검증
+            // And
             TransactionTemplate txTemplate = new TransactionTemplate(txManager);
             txTemplate.executeWithoutResult(status -> {
                 List<Post> posts = postRepository.findAll();
@@ -223,32 +223,29 @@ public class PostIntegrationTest {
         @DisplayName("게시글 삭제 요청 시 DB에서 삭제되고 이미지도 함께 삭제된다")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
         void deletePost_thenCascadeDeleteWorks() throws Exception {
-            // Given: 게시글 생성 (이미지 2장 업로드됨)
+            // Given
             Long postId = createPostAsLoggedInUser("삭제용 제목", "img1.jpg");
 
-            // 삭제할 S3 키 미리 확보 (DB는 곧 지울 것이므로 지금 땡겨둡니다)
             List<String> keysToDelete = postImageRepository.findByPostId(postId).stream()
-                    .map(PostImage::getS3Url)        // ex) http://127.0.0.1:4566/<bucket>/post/xxx.jpg
-                    .map(this::extractS3Key)         // -> "post/xxx.jpg"
+                    .map(PostImage::getS3Url)
+                    .map(this::extractS3Key)
                     .toList();
             assertThat(keysToDelete).hasSize(2);
 
-            // When: 컨트롤러로 삭제 요청 (내부에서 PostImageService.deleteAllByPost(@Transactional) 커밋 발생)
+            // When
             mockMvc.perform(delete("/api/post/" + postId).with(csrf()))
                     .andExpect(status().isNoContent());
 
-            // Then: DB 삭제 확인
+            // Then
             assertThat(postRepository.findById(postId)).isEmpty();
             assertThat(postImageRepository.findByPostId(postId)).isEmpty();
 
-            // And: S3 삭제 확인 (커밋 이후 afterCommit 훅에서 실제 삭제됨)
+            // And
             assertS3ObjectsDeleted(keysToDelete);
         }
 
         /** Test용: S3 URL -> "post/파일명" 키로 변환 */
         private String extractS3Key(String url) {
-            // 서비스와 동일하게 파일명만 뽑아서 prefix를 붙여줍니다.
-            // s3Service.extractFileName(url)을 쓰셔도 됩니다.
             int slash = url.lastIndexOf('/');
             String fileName = (slash >= 0) ? url.substring(slash + 1) : url;
             return "post/" + fileName;
@@ -256,7 +253,6 @@ public class PostIntegrationTest {
 
         /** Test용: 버킷에 남아있는지 검사해서 남아 있으면 실패 */
         private void assertS3ObjectsDeleted(List<String> expectedDeletedKeys) {
-            // listObjectsV2 로 현재 버킷의 post/ 프리픽스 객체를 모아 비교
             var listed = s3Client.listObjectsV2(b -> b.bucket(bucketName).prefix("post/"));
             var existingKeys = listed.contents().stream().map(S3Object::key).collect(Collectors.toSet());
 
@@ -318,10 +314,10 @@ public class PostIntegrationTest {
         @DisplayName("새로운 이미지만 업로드하고 기존 이미지는 유지된다")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void updatePost_whenOnlyUploadImages_thenSuccess() throws Exception {
-            // Given: 기존 이미지 2장이 등록된 게시글 생성
+            // Given
             Long postId = createPostAsLoggedInUser("초기 제목", "img1.jpg");
 
-            // When: 새 이미지 업로드 (img3)
+            // When
             MockMultipartFile image3 = new MockMultipartFile("images", "img3.jpg", "image/jpeg", "data3".getBytes());
             mockMvc.perform(multipart("/api/post/" + postId)
                             .file(image3)
@@ -330,7 +326,7 @@ public class PostIntegrationTest {
                             .with(req -> { req.setMethod("PUT"); return req; }))
                     .andExpect(status().isOk());
 
-            // Then: 이미지 3장이 등록되어 있고 썸네일이 img3로 변경됨
+            // Then
             TransactionTemplate tx = new TransactionTemplate(txManager);
             tx.executeWithoutResult(status -> {
                 Post updated = postRepository.findById(postId).orElseThrow();
@@ -339,7 +335,7 @@ public class PostIntegrationTest {
                 assertThat(allImages).hasSize(3);
                 assertThat(updated.getThumbnail()).isEqualTo(allImages.get(0).getS3Url());
 
-                // And: 모든 S3 객체가 존재함
+                // And
                 for (PostImage img : allImages) {
                     assertS3ObjectExists(extractS3Key(img.getS3Url()));
                 }
@@ -350,10 +346,10 @@ public class PostIntegrationTest {
         @DisplayName("제목만 수정하고 새로운 이미지를 업로드하면 기존 이미지는 유지되고 썸네일은 변경된다")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void updatePost_whenTitleAndUploadImages_thenSuccess() throws Exception {
-            // Given: 게시글과 이미지가 생성됨
+            // Given
             Long postId = createPostAsLoggedInUser("초기 제목", "img1.jpg");
 
-            // When: 제목만 변경하고 새 이미지(img3)를 업로드함
+            // When
             MockMultipartFile image3 = new MockMultipartFile("images", "img3.jpg", "image/jpeg", "data3".getBytes());
             mockMvc.perform(multipart("/api/post/" + postId)
                             .file(image3)
@@ -363,7 +359,7 @@ public class PostIntegrationTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.title").value("수정된 제목"));
 
-            // Then: 총 3장 이미지가 등록되어 있고 썸네일이 img3로 변경됨
+            // Then
             TransactionTemplate tx = new TransactionTemplate(txManager);
             tx.executeWithoutResult(status -> {
                 Post updated = postRepository.findById(postId).orElseThrow();
@@ -373,7 +369,7 @@ public class PostIntegrationTest {
                 assertThat(updated.getTitle()).isEqualTo("수정된 제목");
                 assertThat(updated.getThumbnail()).isEqualTo(allImages.get(0).getS3Url());
 
-                // And: 모든 S3 객체가 존재해야 함
+                // And
                 for (PostImage img : allImages) {
                     assertS3ObjectExists(extractS3Key(img.getS3Url()));
                 }
@@ -385,13 +381,13 @@ public class PostIntegrationTest {
         @DisplayName("제목만 수정하고 이미지 1개만 삭제할 경우 예외가 발생하고 기존 상태가 유지된다(현행 동작 기준)")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void updatePost_whenTitleAndDeleteImages_thenThrowsExceptionAndRollback() throws Exception {
-            // Given: 게시글 생성(이미지 2장)
+            // Given
             Long postId = createPostAsLoggedInUser("초기 제목", "img1.jpg");
             List<PostImage> originalImages = postImageRepository.findByPostId(postId);
             String deleteTargetUrl = originalImages.get(0).getS3Url();
             String remainingUrl   = originalImages.get(1).getS3Url();
 
-            // When: 업로드 없이 1장만 삭제 → 비즈니스 규칙 위반으로 예외
+            // When
             MockMultipartFile empty = new MockMultipartFile(
                     "images", "", "application/octet-stream", new byte[0]); // 업로드 없음
 
@@ -407,7 +403,7 @@ public class PostIntegrationTest {
                         assertThat(ex).isEqualTo("PostImageUpdateCountException");
                     });
 
-            // Then (서비스 수정 없음, 현행 동작 기준):
+            // Then
             Post post = postRepository.findById(postId)
                     .orElseThrow(() -> new AssertionError("게시글이 존재해야 함"));
 
@@ -437,18 +433,18 @@ public class PostIntegrationTest {
         @DisplayName("게시글 비활성화 요청 시 isDeleted가 true로 변경된다")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void disablePost_thenPostMarkedAsDeleted() throws Exception {
-            // Given: 게시글이 생성됨
+            // Given
             Long postId = createPostAsLoggedInUser("비활성화 테스트", "img1.jpg");
 
-            // When: 비활성화 요청 실행
+            // When
             mockMvc.perform(
                             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                                     .patch("/api/post/" + postId + "/disable")
                                     .with(csrf()))
-                    // Then: 요청이 성공하고 상태코드는 204
+                    // Then:
                     .andExpect(status().isNoContent());
 
-            // And: DB에서 해당 게시글 isDeleted = true
+            // And
             TransactionTemplate tx = new TransactionTemplate(txManager);
             tx.executeWithoutResult(status -> {
                 Post disabledPost = postRepository.findById(postId).orElseThrow();
@@ -460,17 +456,17 @@ public class PostIntegrationTest {
         @DisplayName("존재하지 않는 게시글에 대해 비활성화 요청 시 예외가 발생한다")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
         void disablePost_whenPostNotFound_thenFail() throws Exception {
-            // Given: 존재하지 않는 게시글 ID
+            // Given
             Long invalidId = 9999L;
 
-            // When: 비활성화 요청 실행
+            // When
             mockMvc.perform(
                             org.springframework.test.web.servlet.request.MockMvcRequestBuilders
                                     .patch("/api/post/" + invalidId + "/disable")
                                     .with(csrf()))
-                    // Then: 404 Not Found 응답
+                    // Then
                     .andExpect(status().isNotFound())
-                    // And: 예외 클래스명이 PostNotFoundException
+                    // And
                     .andExpect(result -> {
                         String exName = result.getResolvedException().getClass().getSimpleName();
                         assertThat(exName).isEqualTo("PostNotFoundException");
@@ -486,12 +482,12 @@ public class PostIntegrationTest {
         @DisplayName("ROLE_USER가 게시글 삭제 요청 시 403 Forbidden")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void deletePost_whenUser_thenForbidden() throws Exception {
-            // Given: 게시글 생성
+            // Given
             Long postId = createPostAsLoggedInUser("비활성화 테스트", "img1.jpg");
 
-            // When: 삭제 요청 실행 (ROLE_USER)
+            // When
             mockMvc.perform(delete("/api/post/" + postId).with(csrf()))
-                    // Then: 403 Forbidden 응답
+                    // Then
                     .andExpect(status().isForbidden());
         }
 
@@ -499,9 +495,9 @@ public class PostIntegrationTest {
         @Test
         @DisplayName("비로그인 사용자가 게시글 수정 시도 시 401 isUnauthorized")
         void updatePost_whenAnonymous_thenUnauthorized() throws Exception {
-            // Given: 비로그인 사용자가 게시글 접근 (mockPost는 사전 세팅됨)
+            // Given
 
-            // When: 수정 요청 실행
+            // When
             mockMvc.perform(multipart("/api/post/" + mockPost.getId())
                             .file(new MockMultipartFile("images", "", "application/octet-stream", new byte[0]))
                             .param("title", "변경됨")
@@ -517,14 +513,14 @@ public class PostIntegrationTest {
         @DisplayName("존재하지 않는 게시글 삭제 시도 시 404 Not Found")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_ADMIN)
         void deletePost_whenNotFound_thenFail() throws Exception {
-            // Given: 존재하지 않는 게시글 ID
+            // Given
             Long invalidId = 9999L;
 
-            // When: 삭제 요청 실행
+            // When
             mockMvc.perform(delete("/api/post/" + invalidId).with(csrf()))
-                    // Then: 404 Not Found 응답
+                    // Then
                     .andExpect(status().isNotFound())
-                    // And: 예외 클래스명이 PostNotFoundException
+                    // And
                     .andExpect(result ->
                             assertThat(result.getResolvedException().getClass().getSimpleName())
                                     .isEqualTo("PostNotFoundException")
@@ -535,7 +531,7 @@ public class PostIntegrationTest {
         @DisplayName("존재하지 않는 게시글 수정 시도 시 404 Not Found")
         @WithMockMember(nickname = "행복한돼지", provider = OAuthProvider.NAVER, role = MemberRole.ROLE_USER)
         void updatePost_whenNotFound_thenFail() throws Exception {
-            // Given: 존재하지 않는 게시글 ID
+            // Given
             long nonExistentPostId = 9999L;
 
             // JSON part
@@ -548,7 +544,7 @@ public class PostIntegrationTest {
                     "updatePostRequest", "updatePostRequest.json", "application/json", json.getBytes(StandardCharsets.UTF_8)
             );
 
-            // 빈 이미지
+
             MockMultipartFile emptyImages = new MockMultipartFile("images", "", "application/octet-stream", new byte[0]);
 
             // When & Then
@@ -585,7 +581,7 @@ public class PostIntegrationTest {
                     .andExpect(status().isOk())
                     .andReturn();
 
-            // Then: 모델에서 직접 검증
+            // Then
             ModelMap modelMap = result.getModelAndView().getModelMap();
             List<PostResponse> posts = (List<PostResponse>) modelMap.get("posts");
 

--- a/src/test/java/kr/co/pinup/posts/service/PostServiceIntegrationTest.java
+++ b/src/test/java/kr/co/pinup/posts/service/PostServiceIntegrationTest.java
@@ -13,7 +13,6 @@ import kr.co.pinup.oauth.OAuthProvider;
 import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageUpdateCountException;
 import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
-import kr.co.pinup.postImages.model.dto.PostImageResponse;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.postImages.service.PostImageService;
 import kr.co.pinup.postLikes.PostLike;
@@ -38,12 +37,10 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -216,7 +213,6 @@ public class PostServiceIntegrationTest {
         assertEquals("Updated", result.title());
         assertEquals("Content", result.content());
 
-        // ✅ 핵심 검증: 남은 이미지 중 첫 번째(remain_url)가 썸네일로 유지됨
         assertEquals("remain_url", result.thumbnail());
 
         verify(postImageService).uploadImagesOnly(any(CreatePostImageRequest.class));
@@ -259,7 +255,6 @@ public class PostServiceIntegrationTest {
 
         Long postId = mockPost.getId();
 
-        // Mock: 업로드 로직
         List<String> uploadedUrls = List.of(
                 "https://s3.com/file1.jpg",
                 "https://s3.com/file2.jpg"
@@ -267,13 +262,11 @@ public class PostServiceIntegrationTest {
         when(postImageService.uploadImagesOnly(any(CreatePostImageRequest.class)))
                 .thenReturn(uploadedUrls);
 
-        // Mock: DB 저장 로직
         PostImage postImage1 = new PostImage(mockPost, uploadedUrls.get(0));
         PostImage postImage2 = new PostImage(mockPost, uploadedUrls.get(1));
         when(postImageService.saveImageUrls(any(Post.class), eq(uploadedUrls)))
                 .thenReturn(List.of(postImage1, postImage2));
 
-        // 실제 DB에 추가 (기존 url.jpg 유지 + 신규 업로드 추가)
         postImageRepository.save(postImage1);
         postImageRepository.save(postImage2);
 
@@ -284,7 +277,7 @@ public class PostServiceIntegrationTest {
         assertNotNull(result);
         assertEquals("Updated", result.title());
         assertEquals("Content", result.content());
-        assertEquals("https://s3.com/file1.jpg", result.thumbnail()); // ✅ 새 업로드 이미지가 썸네일로 교체됨
+        assertEquals("https://s3.com/file1.jpg", result.thumbnail());
 
         verify(postImageService, atLeastOnce()).uploadImagesOnly(any(CreatePostImageRequest.class));
         verify(postImageService, atLeastOnce()).saveImageUrls(any(Post.class), eq(uploadedUrls));
@@ -313,11 +306,9 @@ public class PostServiceIntegrationTest {
     @DisplayName("게시글 목록 조회 - 로그인 여부와 좋아요 여부에 따른 likedByCurrentUser 필드 검증")
     void findByStoreIdWithCommentsAndLikes_allScenarios() {
         // given
-        // 1. 게시글 2개 생성
         Post post1 = postRepository.save(Post.builder().title("post1").content("c1").member(mockMember).store(mockPost.getStore()).build());
         Post post2 = postRepository.save(Post.builder().title("post2").content("c2").member(mockMember).store(mockPost.getStore()).build());
 
-        // 2. post1에는 좋아요 저장
         postLikeRepository.save(PostLike.builder().post(post1).member(mockMember).build());
 
         MemberInfo memberInfo = new MemberInfo(mockMember.getNickname(), mockMember.getProviderType(), mockMember.getRole());
@@ -330,7 +321,6 @@ public class PostServiceIntegrationTest {
         assertThat(loggedInResult).hasSize(3); // 기존 mockPost + 위에서 만든 post1, post2
         assertThat(anonymousResult).hasSize(3);
 
-        // 로그인한 사용자는 post1만 좋아요 누름
         for (PostResponse response : loggedInResult) {
             if (response.title().equals("post1")) {
                 assertThat(response.likedByCurrentUser()).isTrue();
@@ -339,7 +329,6 @@ public class PostServiceIntegrationTest {
             }
         }
 
-        // 비로그인 사용자는 모두 false
         assertThat(anonymousResult).allSatisfy(resp -> assertThat(resp.likedByCurrentUser()).isFalse());
     }
 

--- a/src/test/java/kr/co/pinup/posts/service/PostServiceIntegrationTest.java
+++ b/src/test/java/kr/co/pinup/posts/service/PostServiceIntegrationTest.java
@@ -177,10 +177,14 @@ public class PostServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("게시물 수정 - 이미지 삭제 및 업로드 포함")
+    @DisplayName("게시물 수정 - 이미지 삭제 및 업로드 포함 (부분 삭제 + 신규 업로드)")
     void updatePost_whenImagesDeletedAndUploaded_thenSuccess() {
         // Given
         UpdatePostRequest req = new UpdatePostRequest("Updated", "Content");
+
+        postImageRepository.deleteAll();
+        postImageRepository.save(new PostImage(mockPost, "img1"));
+        postImageRepository.save(new PostImage(mockPost, "remain_url"));
 
         when(postImageService.uploadImagesOnly(any(CreatePostImageRequest.class)))
                 .thenReturn(List.of("new_url"));
@@ -190,11 +194,12 @@ public class PostServiceIntegrationTest {
         when(postImageService.deleteSelectedImagesDbOnly(eq(mockPost.getId()), eq(List.of("img1"))))
                 .thenReturn(List.of("img1"));
 
-        when(postImageService.findImagesByPostId(mockPost.getId()))
-                .thenReturn(List.of(
-                        PostImageResponse.builder().id(2L).postId(mockPost.getId()).s3Url("remain_url").build(),
-                        PostImageResponse.builder().id(3L).postId(mockPost.getId()).s3Url("new_url").build()
-                ));
+        postImageRepository.findAll().stream()
+                .filter(img -> img.getS3Url().equals("img1"))
+                .findFirst()
+                .ifPresent(postImageRepository::delete);
+
+        postImageRepository.save(new PostImage(mockPost, "new_url"));
 
         MultipartFile img = new MockMultipartFile("img", "file.jpg", "image/jpeg", "data".getBytes());
 
@@ -206,18 +211,19 @@ public class PostServiceIntegrationTest {
                 List.of("img1")
         );
 
-
+        // Then
         assertNotNull(result);
         assertEquals("Updated", result.title());
         assertEquals("Content", result.content());
+
+        // ✅ 핵심 검증: 남은 이미지 중 첫 번째(remain_url)가 썸네일로 유지됨
         assertEquals("remain_url", result.thumbnail());
 
-        verify(postImageService, atLeastOnce()).uploadImagesOnly(any(CreatePostImageRequest.class));
-        verify(postImageService, atLeastOnce()).saveImageUrls(eq(mockPost), eq(List.of("new_url")));
-        verify(postImageService, atLeastOnce()).deleteSelectedImagesDbOnly(mockPost.getId(), List.of("img1"));
-        verify(postImageService, atLeastOnce()).findImagesByPostId(mockPost.getId());
-
+        verify(postImageService).uploadImagesOnly(any(CreatePostImageRequest.class));
+        verify(postImageService).saveImageUrls(eq(mockPost), eq(List.of("new_url")));
+        verify(postImageService).deleteSelectedImagesDbOnly(mockPost.getId(), List.of("img1"));
     }
+
 
     @Test
     @DisplayName("게시물 수정 - 이미지 삭제만")
@@ -225,17 +231,9 @@ public class PostServiceIntegrationTest {
         // Given
         UpdatePostRequest req = new UpdatePostRequest("Updated", "Content");
 
-        when(postImageService.findImagesByPostId(mockPost.getId())).thenReturn(
-                List.of(
-                        PostImageResponse.builder().id(1L).postId(mockPost.getId()).s3Url("img1").build(),
-                        PostImageResponse.builder().id(2L).postId(mockPost.getId()).s3Url("img2").build(),
-                        PostImageResponse.builder().id(3L).postId(mockPost.getId()).s3Url("remaining_image_url.jpg").build()
-                ),
-                List.of(
-                        PostImageResponse.builder().id(2L).postId(mockPost.getId()).s3Url("img2").build(),
-                        PostImageResponse.builder().id(3L).postId(mockPost.getId()).s3Url("remaining_image_url.jpg").build()
-                )
-        );
+        postImageRepository.save(new PostImage(mockPost, "img1"));
+        postImageRepository.save(new PostImage(mockPost, "img2"));
+        postImageRepository.save(new PostImage(mockPost, "remaining_image_url.jpg"));
 
         doNothing().when(postImageService).deleteSelectedImages(eq(mockPost.getId()), any());
 
@@ -248,9 +246,10 @@ public class PostServiceIntegrationTest {
     }
 
     @Test
-    @DisplayName("게시물 수정 - 이미지만 업로드")
+    @DisplayName("게시물 수정 - 이미지만 업로드 (기존 썸네일 교체)")
     void updatePost_whenImagesUploadedOnly_thenSuccess() {
         // Given
+        postImageRepository.deleteAll();
         UpdatePostRequest req = new UpdatePostRequest("Updated", "Content");
 
         MultipartFile[] imgs = {
@@ -258,9 +257,9 @@ public class PostServiceIntegrationTest {
                 new MockMultipartFile("img", "file2.jpg", "image/jpeg", "data2".getBytes())
         };
 
-        Long postId = mockPost.getId(); // ← 실제 DB에 저장된 ID 사용
+        Long postId = mockPost.getId();
 
-        // 업로드 후 S3 URL들이 만들어진다고 가정
+        // Mock: 업로드 로직
         List<String> uploadedUrls = List.of(
                 "https://s3.com/file1.jpg",
                 "https://s3.com/file2.jpg"
@@ -268,18 +267,15 @@ public class PostServiceIntegrationTest {
         when(postImageService.uploadImagesOnly(any(CreatePostImageRequest.class)))
                 .thenReturn(uploadedUrls);
 
-        // URL을 DB에 저장하면 PostImage 리스트를 반환
-        PostImage postImage1 = PostImage.builder().post(mockPost).s3Url(uploadedUrls.get(0)).build();
-        PostImage postImage2 = PostImage.builder().post(mockPost).s3Url(uploadedUrls.get(1)).build();
+        // Mock: DB 저장 로직
+        PostImage postImage1 = new PostImage(mockPost, uploadedUrls.get(0));
+        PostImage postImage2 = new PostImage(mockPost, uploadedUrls.get(1));
         when(postImageService.saveImageUrls(any(Post.class), eq(uploadedUrls)))
-                .thenReturn(List.of(postImage1, postImage2)); // ← any(Post.class) 로 받기
+                .thenReturn(List.of(postImage1, postImage2));
 
-        // 썸네일 갱신 기준용: 현재 이미지 목록(여기서는 업로드 2장만 응답하도록 가정)
-        List<PostImageResponse> uploadedResponses = List.of(
-                PostImageResponse.from(postImage1),
-                PostImageResponse.from(postImage2)
-        );
-        when(postImageService.findImagesByPostId(postId)).thenReturn(uploadedResponses);
+        // 실제 DB에 추가 (기존 url.jpg 유지 + 신규 업로드 추가)
+        postImageRepository.save(postImage1);
+        postImageRepository.save(postImage2);
 
         // When
         PostResponse result = postService.updatePost(postId, req, imgs, List.of());
@@ -288,13 +284,18 @@ public class PostServiceIntegrationTest {
         assertNotNull(result);
         assertEquals("Updated", result.title());
         assertEquals("Content", result.content());
-        assertEquals("https://s3.com/file1.jpg", result.thumbnail()); // remaining.get(0) 규칙에 맞게 첫 이미지
+        assertEquals("https://s3.com/file1.jpg", result.thumbnail()); // ✅ 새 업로드 이미지가 썸네일로 교체됨
+
+        verify(postImageService, atLeastOnce()).uploadImagesOnly(any(CreatePostImageRequest.class));
+        verify(postImageService, atLeastOnce()).saveImageUrls(any(Post.class), eq(uploadedUrls));
     }
 
     @Test
     @DisplayName("게시물 수정 실패 - 모든 이미지 삭제 후 예외 발생 (이미지 2장 미만)")
     void updatePost_whenAllImagesDeleted_thenThrowsException() {
         // Given
+        postImageRepository.deleteAll();
+
         UpdatePostRequest req = new UpdatePostRequest("Updated", "Content");
 
         postImageRepository.save(PostImage.builder()

--- a/src/test/java/kr/co/pinup/posts/service/PostServiceUnitTest.java
+++ b/src/test/java/kr/co/pinup/posts/service/PostServiceUnitTest.java
@@ -12,6 +12,7 @@ import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageUpdateCountException;
 import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
 import kr.co.pinup.postImages.model.dto.PostImageResponse;
+import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.postImages.service.PostImageService;
 import kr.co.pinup.posts.Post;
 import kr.co.pinup.posts.exception.post.PostDeleteFailedException;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -66,7 +68,11 @@ PostServiceUnitTest {
     @Mock
     private StoreRepository storeRepository;
     @Mock
+    private PostImageRepository postImageRepository;
+    @Mock
     private AppLogger appLogger;
+    @Mock
+    private ApplicationEventPublisher events;
 
     @InjectMocks
     private PostService postService;
@@ -296,7 +302,7 @@ PostServiceUnitTest {
             verify(postImageService, never()).uploadImagesOnly(any());
             verify(postImageService, never()).saveImageUrls(any(), anyList());
             verify(postImageService, never()).deleteSelectedImagesDbOnly(anyLong(), anyList());
-            verify(postImageService, never()).findImagesByPostId(anyLong());
+            verify(postImageRepository, never()).findAllByPostIdOrderByIdAsc(anyLong());
             verify(postImageService, never()).cleanupUploadedOnRollback(anyList());
         }
 
@@ -316,7 +322,7 @@ PostServiceUnitTest {
             verify(postImageService, never()).uploadImagesOnly(any());
             verify(postImageService, never()).saveImageUrls(any(), anyList());
             verify(postImageService, never()).deleteSelectedImagesDbOnly(anyLong(), anyList());
-            verify(postImageService, never()).findImagesByPostId(anyLong());
+            verify(postImageRepository, never()).findAllByPostIdOrderByIdAsc(anyLong());
             verify(postImageService, never()).cleanupUploadedOnRollback(anyList());
         }
 
@@ -350,10 +356,10 @@ PostServiceUnitTest {
             when(postImageService.deleteSelectedImagesDbOnly(1L, toDelete))
                     .thenReturn(toDelete);
 
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("img2.jpg").build(),
-                            PostImageResponse.builder().id(3L).postId(1L).s3Url("img3.jpg").build()
+                            new PostImage(post, "img2.jpg"),
+                            new PostImage(post, "img3.jpg")
                     )
             );
 
@@ -362,7 +368,7 @@ PostServiceUnitTest {
             assertEquals("New Title", result.title());
             assertEquals("New Content", result.content());
             assertEquals("img2.jpg", result.thumbnail());
-            verify(postImageService).findImagesByPostId(1L);
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
         @Test
@@ -384,18 +390,17 @@ PostServiceUnitTest {
             when(postImageService.saveImageUrls(eq(post), eq(List.of("new1.jpg"))))
                     .thenReturn(List.of(new PostImage(post, "new1.jpg")));
 
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(1L).postId(1L).s3Url("existing.jpg").build(),
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("new1.jpg").build()
+                            new PostImage(post, "existing.jpg"),
+                            new PostImage(post, "new1.jpg")
                     )
             );
-
             PostResponse result = postService.updatePost(1L, req, upload, List.of());
 
             assertEquals("New Title", result.title());
             assertEquals("existing.jpg", result.thumbnail());
-            verify(postImageService).findImagesByPostId(1L);
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
         @Test
@@ -413,18 +418,17 @@ PostServiceUnitTest {
             when(postImageService.deleteSelectedImagesDbOnly(1L, toDelete))
                     .thenReturn(toDelete);
 
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("img2.jpg").build(),
-                            PostImageResponse.builder().id(3L).postId(1L).s3Url("img3.jpg").build()
+                            new PostImage(post, "img2.jpg"),
+                            new PostImage(post, "img3.jpg")
                     )
             );
-
             PostResponse result = postService.updatePost(1L, req, new MultipartFile[0], toDelete);
 
             assertEquals("New Title", result.title());
             assertEquals("img2.jpg", result.thumbnail());
-            verify(postImageService).findImagesByPostId(1L);
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
         @Test
@@ -446,11 +450,10 @@ PostServiceUnitTest {
             when(postImageService.saveImageUrls(eq(post), eq(List.of("new1.jpg"))))
                     .thenReturn(List.of(new PostImage(post, "new1.jpg")));
 
-            // ★ 변경 '이후' 목록 1회만, 최소 2장. 기존 썸네일이 포함되어 있어야 유지됨
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(1L).postId(1L).s3Url("existing.jpg").build(),
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("new1.jpg").build()
+                            new PostImage(post, "existing.jpg"),
+                            new PostImage(post, "new1.jpg")
                     )
             );
 
@@ -458,7 +461,7 @@ PostServiceUnitTest {
 
             assertEquals("Updated Content", result.content());
             assertEquals("existing.jpg", result.thumbnail()); // 유지
-            verify(postImageService).findImagesByPostId(1L);
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
         @Test
@@ -476,11 +479,10 @@ PostServiceUnitTest {
             when(postImageService.deleteSelectedImagesDbOnly(1L, toDelete))
                     .thenReturn(toDelete);
 
-            // ★ 변경 '이후' 목록을 1회만, 최소 2장, 0번을 기대 썸네일(img2.jpg)로
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("img2.jpg").build(),
-                            PostImageResponse.builder().id(3L).postId(1L).s3Url("img3.jpg").build()
+                            new PostImage(post, "img2.jpg"),
+                            new PostImage(post, "img3.jpg")
                     )
             );
 
@@ -488,7 +490,7 @@ PostServiceUnitTest {
 
             assertEquals("Updated Content", result.content());
             assertEquals("img2.jpg", result.thumbnail());
-            verify(postImageService).findImagesByPostId(1L); // 호출 1회
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
         @Test
@@ -503,17 +505,17 @@ PostServiceUnitTest {
             when(postRepository.findById(1L)).thenReturn(Optional.of(post));
             when(postRepository.save(any())).thenReturn(post);
 
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(1L).postId(1L).s3Url("url1").build(),
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("remain_url1").build(),
-                            PostImageResponse.builder().id(3L).postId(1L).s3Url("remain_url2").build()
+                            new PostImage(post, "url1"),
+                            new PostImage(post, "remain_url1"),
+                            new PostImage(post, "remain_url2")
                     ),
                     List.of(
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("remain_url1").build(),
-                    PostImageResponse.builder().id(3L).postId(1L).s3Url("remain_url2").build()
-        )
-    );
+                            new PostImage(post, "remain_url1"),
+                            new PostImage(post, "remain_url2")
+                    )
+            );
 
             when(postImageService.deleteSelectedImagesDbOnly(1L, toDelete))
                     .thenReturn(toDelete);
@@ -542,11 +544,10 @@ PostServiceUnitTest {
             when(postImageService.saveImageUrls(eq(post), eq(List.of("upload1.jpg"))))
                     .thenReturn(List.of(new PostImage(post, "upload1.jpg")));
 
-            // ★ 최소 2장 반환 (existing 유지 + 새 업로드)
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(1L).postId(1L).s3Url("existing.jpg").build(),
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("upload1.jpg").build()
+                            new PostImage(post, "existing.jpg"),
+                            new PostImage(post, "upload1.jpg")
                     )
             );
 
@@ -582,11 +583,10 @@ PostServiceUnitTest {
             when(postImageService.saveImageUrls(eq(post), eq(List.of("new_url"))))
                     .thenReturn(List.of(new PostImage(post, "new_url")));
 
-            // ★ 변경 '이후' 상태 한 번만, 최소 2장, 0번에 remain_url 배치
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(2L).postId(1L).s3Url("remain_url").build(),
-                            PostImageResponse.builder().id(3L).postId(1L).s3Url("new_url").build()
+                            new PostImage(post, "remain_url"),
+                            new PostImage(post, "new_url")
                     )
             );
 
@@ -597,7 +597,7 @@ PostServiceUnitTest {
             assertEquals("Updated", result.title());
             assertEquals("remain_url", result.thumbnail());
 
-            verify(postImageService).findImagesByPostId(1L); // 호출 1회
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
         @Test
@@ -610,9 +610,12 @@ PostServiceUnitTest {
             MultipartFile[] upload = new MultipartFile[0];
 
             when(postRepository.findById(1L)).thenReturn(Optional.of(post));
-            when(postImageService.findImagesByPostId(1L)).thenReturn(List.of(
-                    PostImageResponse.builder().id(1L).postId(1L).s3Url("url1").build()
-            ));
+
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
+                    List.of(
+                            new PostImage(post, "url1")
+                    )
+            );
 
             assertThrows(PostImageUpdateCountException.class, () ->
                     postService.updatePost(1L, req, upload, toDelete));
@@ -643,11 +646,10 @@ PostServiceUnitTest {
             when(postImageService.saveImageUrls(eq(post), eq(List.of("new1.jpg"))))
                     .thenReturn(List.of(new PostImage(post, "new1.jpg")));
 
-            // ★ 썸네일 갱신에 사용될 "변경 이후" 목록을 단 한 번만 스텁 (2장 이상 필수)
-            when(postImageService.findImagesByPostId(1L)).thenReturn(
+            when(postImageRepository.findAllByPostIdOrderByIdAsc(1L)).thenReturn(
                     List.of(
-                            PostImageResponse.builder().id(10L).postId(1L).s3Url("new1.jpg").build(),
-                            PostImageResponse.builder().id(11L).postId(1L).s3Url("to_keep.jpg").build()
+                            new PostImage(post, "new1.jpg"),
+                            new PostImage(post, "to_keep.jpg")
                     )
             );
 
@@ -660,7 +662,7 @@ PostServiceUnitTest {
             verify(postImageService).deleteSelectedImagesDbOnly(1L, toDelete);
             verify(postImageService).uploadImagesOnly(any(CreatePostImageRequest.class));
             verify(postImageService).saveImageUrls(eq(post), eq(List.of("new1.jpg")));
-            verify(postImageService).findImagesByPostId(1L); // 호출 1회
+            verify(postImageRepository).findAllByPostIdOrderByIdAsc(1L);
         }
 
     }

--- a/src/test/java/kr/co/pinup/posts/service/PostServiceUnitTest.java
+++ b/src/test/java/kr/co/pinup/posts/service/PostServiceUnitTest.java
@@ -11,7 +11,6 @@ import kr.co.pinup.oauth.OAuthProvider;
 import kr.co.pinup.postImages.PostImage;
 import kr.co.pinup.postImages.exception.postimage.PostImageUpdateCountException;
 import kr.co.pinup.postImages.model.dto.CreatePostImageRequest;
-import kr.co.pinup.postImages.model.dto.PostImageResponse;
 import kr.co.pinup.postImages.repository.PostImageRepository;
 import kr.co.pinup.postImages.service.PostImageService;
 import kr.co.pinup.posts.Post;
@@ -31,6 +30,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,9 +38,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
-import static org.mockito.Mockito.*;
-import org.mockito.ArgumentCaptor;
-
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -53,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
 
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## 요약

- **Spring Cache(Caffeine) 도입**: **화이트리스트 기반 Strict CacheManager**로 미리 등록한 캐시명만 허용.
- **after-commit 무효화**: `@TransactionalEventListener(phase = AFTER_COMMIT)`로 **커밋 후** 정밀 `evict` 수행.
- **대상 캐시(예)**: `post:detail`, `post:images` (`CacheNames.POST_DETAIL/POST_IMAGES`).

## 작업 내용

- `CaffeineCacheManager` 커스터마이징
    - `setCacheNames(...)`로 **허용 캐시명 화이트리스트** 적용(동적 생성 차단)
    - 캐시별 **TTL/maximumSize**를 `AppCacheProps`(yml 바인딩)로 주입, `recordStats()` 활성화
- **도메인 이벤트 → 리스너(after-commit)**
    - 이벤트: `PostCacheEvent(Kind: UPDATED/DISABLED/DELETED, postId, detailChanged, imagesChanged)`
    - 리스너: `PostCacheInvalidationListener`
        - `UPDATED`: `detailChanged` → `post:detail`만 evict, `imagesChanged` → `post:images`만 evict
        - `DISABLED`: `post:detail` evict
        - `DELETED`: `post:detail`, `post:images` 모두 evict

## 참고 사항

- **일관성 보장**: 롤백 시 캐시 변경 없음(무효화는 커밋 이후에만 실행).
- **운영 안전성**: 화이트리스트로 **오타/임의 캐시 생성** 방지.
- **튜닝/관측**: `hit/miss/put/evict/size` 지표 기반으로 TTL/size 조정(초기값 예: TTL 60s / size 1k).
- **yml 예시(요지)**:
    - `spring.cache.type=caffeine`
    - `spring.cache.app.defaults/caches`로 per-cache `ttlSec`, `maximumSize` 설정

## 관련 이슈

- Close #이슈번호